### PR TITLE
Fixed translations file and some tests.

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,6 +4,6 @@ en:
       send_instructions: 'An invitation email has been sent to %{email}.'
       invitation_token_invalid: 'The invitation token provided is not valid!'
       updated: 'Your password was set successfully. You are now signed in.'
-  mailer:
-    invitation_instructions:
-      subject: 'Invitation instructions'
+    mailer:
+      invitation_instructions:
+        subject: 'Invitation instructions'

--- a/test/mailers/invitation_mail_test.rb
+++ b/test/mailers/invitation_mail_test.rb
@@ -48,12 +48,12 @@ class InvitationMailTest < ActionMailer::TestCase
   end
 
   test 'body should have user info' do
-    assert_match /#{user.email}/, mail.body
+    assert_match /#{user.email}/, mail.body.decoded
   end
 
   test 'body should have link to confirm the account' do
     host = ActionMailer::Base.default_url_options[:host]
     invitation_url_regexp = %r{<a href=\"http://#{host}/users/invitation/accept\?invitation_token=#{user.invitation_token}">}
-    assert_match invitation_url_regexp, mail.body
+    assert_match invitation_url_regexp, mail.body.decoded
   end
 end


### PR DESCRIPTION
Hey, first, great gem! Thank's for that!

I changed the indentation depth under the mailer translation because it was en.mailer and not en.devise.mailer (that's the one the code looks for).

Also, fixed 2 tests that were not passing because you were trying to match a "Mail::Body" and it was not the actual string (and it does not have a to_s method). So I just changed _mail.body_ to _mail.body.decoded_ that it's the actual string inside the object.

Thanks a lot again,

Nicolás Hock Isaza
