### PR TITLE
Enable the use of different keys when inviting

### DIFF
--- a/lib/devise_invitable.rb
+++ b/lib/devise_invitable.rb
@@ -19,6 +19,10 @@ module Devise
   #   config.invitation_limit = nil
   mattr_accessor :invitation_limit
   @@invitation_limit = nil
+  
+  # The period the generated invitation token is valid.
+  mattr_accessor :invite_key
+  @@invite_for = :email
 end
 
 Devise.add_module :invitable, :controller => :invitations, :model => 'devise_invitable/model', :route => :invitation

--- a/lib/devise_invitable/model.rb
+++ b/lib/devise_invitable/model.rb
@@ -118,7 +118,7 @@ module Devise
         # email already exists error.
         # Attributes must contain the user email, other attributes will be set in the record
         def invite!(attributes={}, invited_by=nil)
-          invitable = find_or_initialize_with_error_by(:email, attributes.delete(:email))
+          invitable = find_or_initialize_with_error_by(invite_key, attributes.delete(invite_key))
           invitable.attributes = attributes
           invitable.invited_by = invited_by
 
@@ -154,6 +154,7 @@ module Devise
 
         Devise::Models.config(self, :invite_for)
         Devise::Models.config(self, :invitation_limit)
+        Devise::Models.config(self, :invite_key)
       end
     end
   end

--- a/lib/generators/devise_invitable/install_generator.rb
+++ b/lib/generators/devise_invitable/install_generator.rb
@@ -24,6 +24,9 @@ module DeviseInvitable
   # When invite_for is 0 (the default), the invitation won't expire.
   # config.invite_for = 2.weeks
   
+  # The key to be used when sending an invitation
+  # config.invite_key = :email
+  
 CONTENT
             end
           end

--- a/test/models_test.rb
+++ b/test/models_test.rb
@@ -28,6 +28,10 @@ class ModelsTest < ActiveSupport::TestCase
     assert_nil User.invitation_limit
   end
 
+  test 'should have a default value for invite_key' do
+    assert_nil User.invite_key
+  end
+
   test 'set a custom value for invite_for' do
     old_invite_for = User.invite_for
     User.invite_for = 5.days
@@ -37,6 +41,15 @@ class ModelsTest < ActiveSupport::TestCase
     User.invite_for = old_invite_for
   end
 
+  test 'set a custom value for invite_key' do
+    old_invite_key = User.invite_key
+    User.invite_key = :username
+    
+    assert_equal :username, User.invite_key
+    
+    User.invite_key = old_invite_key
+  end 
+  
   test 'set a custom value for invitation_limit' do
     old_invitation_limit = User.invitation_limit
     User.invitation_limit = 2


### PR DESCRIPTION
In my model I had users are allowed to have non-unique email addresses. When this happens inviteable will just find the first record mathcing the email and updated it with the new info. 

Creating a new config option -config.invite_key- enables the developer to chose which key attribute will be used on the find_or_initialize_with_error_by method.

This might help others as well.
