### PR TITLE
Allow to modify record in Model.invite! using block

### DIFF
--- a/lib/devise_invitable/model.rb
+++ b/lib/devise_invitable/model.rb
@@ -127,7 +127,7 @@ module Devise
         # user and send invitation to it. If user is found, returns the user with an
         # email already exists error.
         # Attributes must contain the user email, other attributes will be set in the record
-        def invite!(attributes={}, invited_by=nil)
+        def invite!(attributes={}, invited_by=nil, &block)
           invitable = find_or_initialize_with_error_by(invite_key, attributes.delete(invite_key))
           invitable.attributes = attributes
           invitable.invited_by = invited_by
@@ -138,7 +138,10 @@ module Devise
             invitable.errors.add(invite_key, :taken) unless invitable.invited?
           end
 
-          invitable.invite! if invitable.errors.empty?
+          if invitable.errors.empty?
+            yield invitable if block_given?
+            invitable.invite!
+          end
           invitable
         end
 

--- a/test/models/invitable_test.rb
+++ b/test/models/invitable_test.rb
@@ -225,6 +225,14 @@ class InvitableTest < ActiveSupport::TestCase
     assert_equal ["is invalid"], user.errors[:invitation_token]
   end
 
+  test 'should allow record modification using block' do
+    invited_user = User.invite!(:email => "valid@email.com", :username => "a"*50) do |u|
+      u.password = '123123'
+      u.password_confirmation = '123123'
+    end
+    assert_equal '123123', invited_user.reload.password
+  end
+
   test 'should set successfully user password given the new password and confirmation' do
     user = new_user(:password => nil, :password_confirmation => nil)
     user.invite!


### PR DESCRIPTION
The main purpose of this change is to allow record modification when the invitee is about to be created. 

This was dictated by the following use case which I've came across a lot recently: setting mass assign protected attributes.
    class User
      attr_protected :admin
    end

```
u = User.invite!(:email => 'admin@example.com', :admin => true)
u.admin? #=> false

u = User.invite!(:email => 'admin@example.com') do |u|
  u.admin = true
end
u.admin? #=> true
```

Since the may skip the validation, there is no way to get information whether or not one was invited.
Moreover if the validation will be enabled with some required protected attributes wont be set. 
On other hand
    user = User.new(params)
    user.invite!

allow to check was the invitation successful, but it does not provide key integrity check and force to set invited_by manually.

The work flow can be discussed and adopted according to the requirements and your vision of how it should be done
