### PR TITLE
Fix for issue #59

### DIFF
--- a/lib/devise_invitable/rails.rb
+++ b/lib/devise_invitable/rails.rb
@@ -4,7 +4,10 @@ module DeviseInvitable
     ActiveSupport.on_load(:action_controller) { include DeviseInvitable::Controllers::UrlHelpers }
     ActiveSupport.on_load(:action_view)       { include DeviseInvitable::Controllers::UrlHelpers }
     
-    config.after_initialize do
+    # We use to_prepare instead of after_initialize here because Devise is a Rails engine; its
+    # mailer is reloaded like the rest of the user's app.  Got to make sure that our mailer methods
+    # are included each time Devise::Mailer is (re)loaded.
+    config.to_prepare do
       require 'devise/mailer'
       Devise::Mailer.send :include, DeviseInvitable::Mailer
     end


### PR DESCRIPTION
Hooking up the mailer include to to_prepare instead of after_initialize so that the invitable mailer actions are usable during development
