### PR TITLE
upgrade devise dependency to 1.3.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     devise_invitable (0.4.1)
-      devise (~> 1.2.0)
+      devise (~> 1.3.1)
       rails (~> 3.0.0)
 
 GEM
@@ -53,7 +53,7 @@ GEM
     childprocess (0.1.8)
       ffi (~> 1.0.6)
     culerity (0.2.15)
-    devise (1.2.1)
+    devise (1.3.1)
       bcrypt-ruby (~> 2.1.2)
       orm_adapter (~> 0.0.3)
       warden (~> 1.0.3)
@@ -68,7 +68,7 @@ GEM
       rake (>= 0.8.7)
     i18n (0.5.0)
     json_pure (1.5.1)
-    mail (2.2.15)
+    mail (2.2.17)
       activesupport (>= 2.3.6)
       i18n (>= 0.4.0)
       mime-types (~> 1.16)

--- a/README.rdoc
+++ b/README.rdoc
@@ -182,6 +182,10 @@ The DeviseInvitable mailer uses the same pattern as Devise to create mail subjec
 
 Take a look at the generated locale file (in <tt>config/locales/devise_invitable.en.yml</tt>) to check all available messages.
 
+== Gotchas
+
+If you do not set <tt>reset_password_within</tt> in <tt>config/initializers/devise.rb</tt> before running the create_* migration, the column <tt>reset_password_sent_at</tt> does not get added to your schema. Without this, current devise (1.3.1) :recoverable won't accept password reset tokens and :invitable will fail. You may add this :datetime column manually later.
+
 == Other ORMs
 
 DeviseInvitable supports ActiveRecord and Mongoid, like Devise.

--- a/devise_invitable.gemspec
+++ b/devise_invitable.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   
   {
     'rails'  => '~> 3.0.0',
-    'devise' => '~> 1.2.0'
+    'devise' => '~> 1.3.1'
   }.each do |lib, version|
     s.add_runtime_dependency(lib, version)
   end

--- a/lib/generators/devise_invitable/install_generator.rb
+++ b/lib/generators/devise_invitable/install_generator.rb
@@ -38,6 +38,11 @@ module DeviseInvitable
   # Default: false
   # config.validate_on_invite = true
 
+  # :invitable depends on :recoverable which only works if you set a period to
+  # reset the password within. This setting may be set already up in this file.
+  # Please run the create_* migration after making sure reset_password_within is set.
+  config.reset_password_within ||= 2.days
+
 CONTENT
             end
           end

--- a/test/models/invitable_test.rb
+++ b/test/models/invitable_test.rb
@@ -123,6 +123,11 @@ class InvitableTest < ActiveSupport::TestCase
     user.send(:generate_reset_password_token!)
     assert_present user.reset_password_token
     assert_present user.invitation_token
+    assert user.invited?
+    assert user.valid?
+    assert user.respond_to?(:reset_password_sent_at)
+    assert_not_nil user.reset_password_sent_at
+    assert user.reset_password_period_valid?
     User.reset_password_by_token(:reset_password_token => user.reset_password_token, :password => '123456789', :password_confirmation => '123456789')
     assert_nil user.reload.invitation_token
   end

--- a/test/rails_app/config/initializers/devise.rb
+++ b/test/rails_app/config/initializers/devise.rb
@@ -181,4 +181,6 @@ Devise.setup do |config|
   #   manager.failure_app = AnotherApp
   #   manager.default_strategies(:scope => :user).unshift :some_external_strategy
   # end
+
+  config.reset_password_within ||= 2.days
 end


### PR DESCRIPTION
This patch will make devise_invitable work with devise 1.3.1. 

One problem occurred: devise :recoverable only accepts (and resets) password tokens if the auth model has a column called <tt>reset_password_sent_at</tt>, which is only created by the schema method if config.reset_password_within is present.

I am not sure if this is a bug in devise or it is intended.
