### PR TITLE
Fixed issue due to the rename of "setup_mail" to "devise_mail" in Devise 1.4.1/1.4.2

### DIFF
--- a/lib/devise_invitable/mailer.rb
+++ b/lib/devise_invitable/mailer.rb
@@ -3,7 +3,7 @@ module DeviseInvitable
     
     # Deliver an invitation email
     def invitation_instructions(record)
-      setup_mail(record, :invitation_instructions)
+      devise_mail(record, :invitation_instructions)
     end
     
     def invitation(record)


### PR DESCRIPTION
Fixed issue brought by https://github.com/plataformatec/devise/commit/42f028527883bc640e8e2aa5d6eddfd6679bc0ec
