### PR TITLE
Deprecation warning fixed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ tmtags
 ## VIM
 *.swp
 
+##RubyMine
+.idea
+
 ## PROJECT::GENERAL
 coverage
 rdoc

--- a/lib/devise_invitable/controllers/helpers.rb
+++ b/lib/devise_invitable/controllers/helpers.rb
@@ -1,7 +1,7 @@
 module DeviseInvitable::Controllers::Helpers
   protected
   def authenticate_inviter!
-    send(:"authenticate_#{resource_name}!", true)
+    send(:"authenticate_#{resource_name}!", :force => true)
   end
 end
 ActionController::Base.send :include, DeviseInvitable::Controllers::Helpers


### PR DESCRIPTION
Devise API changed, causing deprecation error as in commit message:
"DEPRECATION WARNING: Passing a boolean to authenticate_person! is deprecated, please use :force => true instead. (called from post at /home/denis/.rvm/rubies/ruby-1.9.2-p290/lib/ruby/1.9.1/forwardable.rb:182)"
This commit fixes it.
