### PR TITLE
fixed deprecation in the authentificate_user! method

### DIFF
--- a/lib/devise_invitable/controllers/helpers.rb
+++ b/lib/devise_invitable/controllers/helpers.rb
@@ -1,7 +1,7 @@
 module DeviseInvitable::Controllers::Helpers
   protected
   def authenticate_inviter!
-    send(:"authenticate_#{resource_name}!", true)
+    send(:"authenticate_#{resource_name}!", :force => true)
   end
 end
 ActionController::Base.send :include, DeviseInvitable::Controllers::Helpers


### PR DESCRIPTION
Get rid off deprecation message by passing a :force parameter to authentificate_user! method instead of boolean
