### PR TITLE
add invite_mail! method that returns a Mail object

### DIFF
--- a/test/models/invitable_test.rb
+++ b/test/models/invitable_test.rb
@@ -85,6 +85,11 @@ class InvitableTest < ActiveSupport::TestCase
     end
   end
 
+  test 'should return mail object' do
+    mail = User.invite_mail!(:email => 'valid@email.com')
+    assert mail.class.name == 'Mail::Message'
+  end
+  
   test 'should disallow login when invited' do
     invited_user = User.invite!(:email => "valid@email.com")
     assert !invited_user.valid_password?('1234')


### PR DESCRIPTION
This is more of a "what do you think of this changeset" pull request. This adds a new method called "invite_mail!" which returns the Mail object instead of the invitable object. With this changeset I can use mail_view (https://github.com/37signals/mail_view) to preview the invitation email in the browser.
