### PR TITLE
Remove deprecation notice

### DIFF
--- a/app/controllers/devise/invitations_controller.rb
+++ b/app/controllers/devise/invitations_controller.rb
@@ -61,7 +61,7 @@ class Devise::InvitationsController < ApplicationController
   end
 
   def after_invite_path_for(resource)
-    redirect_location(resource_name, resource)
+    after_sign_in_path_for(resource)
   end
 
   def after_accept_path_for(resource)


### PR DESCRIPTION
The redirect_location method has been deprecated in Devise.
