### PR TITLE
Fix issue when used with devise case_insensitive_keys and strip_whitespace_keys

### DIFF
--- a/lib/devise_invitable/model.rb
+++ b/lib/devise_invitable/model.rb
@@ -56,6 +56,11 @@ module Devise
         self.skip_confirmation! if self.new_record? && self.respond_to?(:skip_confirmation!)
         generate_invitation_token if self.invitation_token.nil?
         self.invitation_sent_at = Time.now.utc
+        
+        # Call these before_validate methods since we aren't validating on save
+        self.downcase_keys if self.new_record? && self.respond_to?(:downcase_keys)
+        self.strip_whitespace if self.new_record? && self.respond_to?(:strip_whitespace)
+        
         if save(:validate => false)
           self.invited_by.decrement_invitation_limit! if !was_invited and self.invited_by.present?
           deliver_invitation unless @skip_invitation


### PR DESCRIPTION
Devise downcases and strips keys listed in case_insensitive_keys and strip_whitespace_keys, respectively. 

https://github.com/plataformatec/devise/blob/master/lib/devise/models/authenticatable.rb#L63

These before_validations don't get triggered by devise_invitable because it saves without validations. This means, for example, that an email address like CAPITALS@gmail.com can be saved to the database. That user won't be able to sign in at all since devise expects the email field in the database to be downcased and stripped!
