### PR TITLE
The migration example should include the column type :string

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -65,9 +65,9 @@ or for a model that already exists, define a migration to add DeviseInvitable to
   end
 
   # Allow null encrypted_password
-  change_column :users, :encrypted_password, :null => true
+  change_column :users, :encrypted_password, :string, :null => true
   # Allow null password_salt (add it if you are using Devise's encryptable module)
-  change_column :users, :password_salt, :null => true
+  change_column :users, :password_salt, :string, :null => true
 
 == Model configuration
 


### PR DESCRIPTION
 If not we will get nasty `undefined method `to_sym' for {:null=>true}:Hash`
