### PR TITLE
Add scopes to find those users that have and have not accepted invitations

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -171,6 +171,13 @@ A callback event is fired before and after an invitation is accepted (User#accep
 
 The callbacks support all options and arguments available to the standard callbacks provided by AR.
 
+=== Scopes
+
+A pair of scopes to find those users that have accepted, and those that have not accepted, invitations are defined:
+
+  User.invitation_accepted # => returns all Users for whom the invitation_accepted_at attribute is not nil
+  User.invitation_not_accepted # => returns all Users for whom the invitation_accepted_at attribute is nil
+
 == Integration in a Rails application
 
 Since the invitations controller take care of all the creation/acceptation of an invitation, in most cases you wouldn't call the <tt>invite!</tt> and <tt>accept_invitation!</tt> methods directly.

--- a/lib/devise_invitable/model.rb
+++ b/lib/devise_invitable/model.rb
@@ -34,6 +34,9 @@ module Devise
         define_callbacks :invitation_accepted
         
         attr_writer :skip_password
+
+        scope :invitation_not_accepted, where(:invitation_accepted_at => nil)
+        scope :invitation_accepted, where("invitation_accepted_at IS NOT NULL")
       end
 
       def self.required_fields(klass)

--- a/test/models/invitable_test.rb
+++ b/test/models/invitable_test.rb
@@ -431,4 +431,25 @@ class InvitableTest < ActiveSupport::TestCase
     assert !user.errors.empty?
   end
 
+  test "Invitable has an invitation_not_accepted scope" do
+    unaccepted_user = User.invite!(:email => "invalid@email.com")
+    unaccepted_user.username = 'test'
+
+    user = User.invite!(:email => "valid@email.com")
+    user.username = 'test'
+    user.accept_invitation!
+
+    assert_equal 1, User.invitation_not_accepted.count
+  end
+
+  test "Invitable has an invitation_accepted scope" do
+    unaccepted_user = User.invite!(:email => "invalid@email.com")
+    unaccepted_user.username = 'test'
+
+    user = User.invite!(:email => "valid@email.com")
+    user.username = 'test'
+    user.accept_invitation!
+
+    assert_equal 1, User.invitation_accepted.count
+  end
 end


### PR DESCRIPTION
This is simple syntactice sugar but has been useful in my workflow.  Maybe there should be other accessor scopes as well?  By providing them we can allow users to access Users with various properties without coupling them to the underlying schema.

I realize this pull-request comes out of thin air and may not fit in the view of the project.  Please feel free to let me know how/if this should be changed if it were to be merged.

Cheers,
Dave
