### PR TITLE
Fix dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ group :test do
     gem "sqlite3", "~> 1.3.4"
   end
 
+  gem 'activerecord', '~> 3.0'
   gem "mongoid", "~> 2.3"
   gem "bson_ext", "~> 1.3"
   gem "capybara", "~> 1.1.0"

--- a/devise_invitable.gemspec
+++ b/devise_invitable.gemspec
@@ -21,8 +21,10 @@ Gem::Specification.new do |s|
   s.add_development_dependency('bundler', '>= 1.1.0')
 
   {
-    'rails'  => '~> 3.0',
-    'devise' => '>= 2.0.0'
+    'railties' => '~> 3.0',
+    'actionmailer' => '~> 3.0',
+    'activeresource' => '~> 3.0',
+    'devise'   => '>= 2.0.0'
   }.each do |lib, version|
     s.add_runtime_dependency(lib, *version)
   end


### PR DESCRIPTION
Currently devise_invitable depends on Rails this means that it also depends on activerecord, which makes it impossible to use in a project without activerecord.
