### PR TITLE
Avoid connecting to database on model load.

### DIFF
--- a/lib/devise_invitable/model.rb
+++ b/lib/devise_invitable/model.rb
@@ -39,11 +39,11 @@ module Devise
 
         attr_writer :skip_password
 
-        scope :invitation_not_accepted, where(:invitation_accepted_at => nil)
+        scope :invitation_not_accepted, lambda { where(:invitation_accepted_at => nil) }
         if defined?(Mongoid) && self < Mongoid::Document
-          scope :invitation_accepted, where(:invitation_accepted_at.ne => nil)
+          scope :invitation_accepted, lambda { where(:invitation_accepted_at.ne => nil) }
         else
-          scope :invitation_accepted, where(arel_table[:invitation_accepted_at].not_eq(nil))
+          scope :invitation_accepted, lambda { where(arel_table[:invitation_accepted_at].not_eq(nil)) }
         end
       end
 


### PR DESCRIPTION
After upgrading from `1.0.2` to `1.0.3` I started getting errors on Jenkins/CI, which doesn't have development tables. I have found that `scope` method executes SQL query to get column/schema information, so I have added `lambda` around those scopes.

```
+ bundle exec rake db:test:load --trace
** Invoke db:test:load (first_time)
** Invoke db:test:purge (first_time)
** Invoke environment (first_time)
** Execute environment
rake aborted!
Mysql2::Error: Table 'bte_development.contacts' doesn't exist: SHOW FULL FIELDS FROM `contacts`
/var/lib/jenkins/.gem/ruby/1.9.1/gems/activerecord-3.2.6/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:243:in `query'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/activerecord-3.2.6/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:243:in `block in execute'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/activerecord-3.2.6/lib/active_record/connection_adapters/abstract_adapter.rb:280:in `block in log'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/activesupport-3.2.6/lib/active_support/notifications/instrumenter.rb:20:in `instrument'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/activerecord-3.2.6/lib/active_record/connection_adapters/abstract_adapter.rb:275:in `log'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/activerecord-3.2.6/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:243:in `execute'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/activerecord-3.2.6/lib/active_record/connection_adapters/mysql2_adapter.rb:211:in `execute'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/activerecord-3.2.6/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:257:in `execute_and_free'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/activerecord-3.2.6/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:424:in `columns'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/activerecord-3.2.6/lib/active_record/connection_adapters/schema_cache.rb:12:in `block in initialize'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/activerecord-3.2.6/lib/active_record/model_schema.rb:228:in `yield'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/activerecord-3.2.6/lib/active_record/model_schema.rb:228:in `default'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/activerecord-3.2.6/lib/active_record/model_schema.rb:228:in `columns'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/activerecord-3.2.6/lib/active_record/model_schema.rb:237:in `columns_hash'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/activerecord-3.2.6/lib/active_record/inheritance.rb:19:in `descends_from_active_record?'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/activerecord-3.2.6/lib/active_record/inheritance.rb:25:in `finder_needs_type_condition?'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/activerecord-3.2.6/lib/active_record/base.rb:455:in `relation'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/activerecord-3.2.6/lib/active_record/scoping/named.rb:37:in `scoped'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/activerecord-3.2.6/lib/active_record/querying.rb:9:in `where'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/devise_invitable-1.0.3/lib/devise_invitable/model.rb:42:in `block in <module:Invitable>'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/activesupport-3.2.6/lib/active_support/concern.rb:119:in `class_eval'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/activesupport-3.2.6/lib/active_support/concern.rb:119:in `append_features'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/devise-2.1.2/lib/devise/models.rb:112:in `include'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/devise-2.1.2/lib/devise/models.rb:112:in `block (2 levels) in devise'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/devise-2.1.2/lib/devise/models.rb:92:in `each'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/devise-2.1.2/lib/devise/models.rb:92:in `block in devise'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/devise-2.1.2/lib/devise/models.rb:123:in `devise_modules_hook!'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/devise-2.1.2/lib/devise/models.rb:90:in `devise'
/var/lib/jenkins/jobs/bte/workspace/app/models/contact.rb:4:in `<class:Contact>'
/var/lib/jenkins/jobs/bte/workspace/app/models/contact.rb:3:in `<top (required)>'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/activesupport-3.2.6/lib/active_support/dependencies.rb:469:in `load'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/activesupport-3.2.6/lib/active_support/dependencies.rb:469:in `block in load_file'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/activesupport-3.2.6/lib/active_support/dependencies.rb:639:in `new_constants_in'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/activesupport-3.2.6/lib/active_support/dependencies.rb:468:in `load_file'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/activesupport-3.2.6/lib/active_support/dependencies.rb:353:in `require_or_load'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/activesupport-3.2.6/lib/active_support/dependencies.rb:502:in `load_missing_constant'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/activesupport-3.2.6/lib/active_support/dependencies.rb:192:in `block in const_missing'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/activesupport-3.2.6/lib/active_support/dependencies.rb:190:in `each'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/activesupport-3.2.6/lib/active_support/dependencies.rb:190:in `const_missing'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/activesupport-3.2.6/lib/active_support/inflector/methods.rb:229:in `block in constantize'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/activesupport-3.2.6/lib/active_support/inflector/methods.rb:228:in `each'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/activesupport-3.2.6/lib/active_support/inflector/methods.rb:228:in `constantize'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/activesupport-3.2.6/lib/active_support/dependencies.rb:554:in `get'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/activesupport-3.2.6/lib/active_support/dependencies.rb:588:in `constantize'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/devise-2.1.2/lib/devise.rb:256:in `get'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/devise-2.1.2/lib/devise/mapping.rb:77:in `to'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/devise-2.1.2/lib/devise/mapping.rb:72:in `modules'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/devise-2.1.2/lib/devise/mapping.rb:89:in `routes'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/devise-2.1.2/lib/devise/mapping.rb:156:in `default_used_route'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/devise-2.1.2/lib/devise/mapping.rb:66:in `initialize'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/devise-2.1.2/lib/devise.rb:290:in `new'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/devise-2.1.2/lib/devise.rb:290:in `add_mapping'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/devise-2.1.2/lib/devise/rails/routes.rb:208:in `block in devise_for'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/devise-2.1.2/lib/devise/rails/routes.rb:207:in `each'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/devise-2.1.2/lib/devise/rails/routes.rb:207:in `devise_for'
/var/lib/jenkins/jobs/bte/workspace/config/routes.rb:3:in `block in <top (required)>'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/actionpack-3.2.6/lib/action_dispatch/routing/route_set.rb:282:in `instance_exec'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/actionpack-3.2.6/lib/action_dispatch/routing/route_set.rb:282:in `eval_block'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/actionpack-3.2.6/lib/action_dispatch/routing/route_set.rb:260:in `draw'
/var/lib/jenkins/jobs/bte/workspace/config/routes.rb:1:in `<top (required)>'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/activesupport-3.2.6/lib/active_support/dependencies.rb:245:in `load'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/activesupport-3.2.6/lib/active_support/dependencies.rb:245:in `block in load'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/activesupport-3.2.6/lib/active_support/dependencies.rb:236:in `load_dependency'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/activesupport-3.2.6/lib/active_support/dependencies.rb:245:in `load'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/railties-3.2.6/lib/rails/application/routes_reloader.rb:40:in `block in load_paths'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/railties-3.2.6/lib/rails/application/routes_reloader.rb:40:in `each'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/railties-3.2.6/lib/rails/application/routes_reloader.rb:40:in `load_paths'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/railties-3.2.6/lib/rails/application/routes_reloader.rb:16:in `reload!'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/railties-3.2.6/lib/rails/application/routes_reloader.rb:26:in `block in updater'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/activesupport-3.2.6/lib/active_support/file_update_checker.rb:78:in `call'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/activesupport-3.2.6/lib/active_support/file_update_checker.rb:78:in `execute'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/railties-3.2.6/lib/rails/application/routes_reloader.rb:27:in `updater'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/railties-3.2.6/lib/rails/application/routes_reloader.rb:7:in `execute_if_updated'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/railties-3.2.6/lib/rails/application/finisher.rb:66:in `block in <module:Finisher>'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/railties-3.2.6/lib/rails/initializable.rb:30:in `instance_exec'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/railties-3.2.6/lib/rails/initializable.rb:30:in `run'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/railties-3.2.6/lib/rails/initializable.rb:55:in `block in run_initializers'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/railties-3.2.6/lib/rails/initializable.rb:54:in `each'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/railties-3.2.6/lib/rails/initializable.rb:54:in `run_initializers'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/railties-3.2.6/lib/rails/application.rb:136:in `initialize!'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/railties-3.2.6/lib/rails/railtie/configurable.rb:30:in `method_missing'
/var/lib/jenkins/jobs/bte/workspace/config/environment.rb:5:in `<top (required)>'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/activesupport-3.2.6/lib/active_support/dependencies.rb:251:in `require'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/activesupport-3.2.6/lib/active_support/dependencies.rb:251:in `block in require'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/activesupport-3.2.6/lib/active_support/dependencies.rb:236:in `load_dependency'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/activesupport-3.2.6/lib/active_support/dependencies.rb:251:in `require'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/railties-3.2.6/lib/rails/application.rb:103:in `require_environment!'
/var/lib/jenkins/.gem/ruby/1.9.1/gems/railties-3.2.6/lib/rails/application.rb:292:in `block (2 levels) in initialize_tasks'
/usr/local/lib/ruby/1.9.1/rake/task.rb:205:in `call'
/usr/local/lib/ruby/1.9.1/rake/task.rb:205:in `block in execute'
/usr/local/lib/ruby/1.9.1/rake/task.rb:200:in `each'
/usr/local/lib/ruby/1.9.1/rake/task.rb:200:in `execute'
/usr/local/lib/ruby/1.9.1/rake/task.rb:158:in `block in invoke_with_call_chain'
/usr/local/lib/ruby/1.9.1/monitor.rb:211:in `mon_synchronize'
/usr/local/lib/ruby/1.9.1/rake/task.rb:151:in `invoke_with_call_chain'
/usr/local/lib/ruby/1.9.1/rake/task.rb:176:in `block in invoke_prerequisites'
/usr/local/lib/ruby/1.9.1/rake/task.rb:174:in `each'
/usr/local/lib/ruby/1.9.1/rake/task.rb:174:in `invoke_prerequisites'
/usr/local/lib/ruby/1.9.1/rake/task.rb:157:in `block in invoke_with_call_chain'
/usr/local/lib/ruby/1.9.1/monitor.rb:211:in `mon_synchronize'
/usr/local/lib/ruby/1.9.1/rake/task.rb:151:in `invoke_with_call_chain'
/usr/local/lib/ruby/1.9.1/rake/task.rb:176:in `block in invoke_prerequisites'
/usr/local/lib/ruby/1.9.1/rake/task.rb:174:in `each'
/usr/local/lib/ruby/1.9.1/rake/task.rb:174:in `invoke_prerequisites'
/usr/local/lib/ruby/1.9.1/rake/task.rb:157:in `block in invoke_with_call_chain'
/usr/local/lib/ruby/1.9.1/monitor.rb:211:in `mon_synchronize'
/usr/local/lib/ruby/1.9.1/rake/task.rb:151:in `invoke_with_call_chain'
/usr/local/lib/ruby/1.9.1/rake/task.rb:144:in `invoke'
/usr/local/lib/ruby/1.9.1/rake/application.rb:116:in `invoke_task'
/usr/local/lib/ruby/1.9.1/rake/application.rb:94:in `block (2 levels) in top_level'
/usr/local/lib/ruby/1.9.1/rake/application.rb:94:in `each'
/usr/local/lib/ruby/1.9.1/rake/application.rb:94:in `block in top_level'
/usr/local/lib/ruby/1.9.1/rake/application.rb:133:in `standard_exception_handling'
/usr/local/lib/ruby/1.9.1/rake/application.rb:88:in `top_level'
/usr/local/lib/ruby/1.9.1/rake/application.rb:66:in `block in run'
/usr/local/lib/ruby/1.9.1/rake/application.rb:133:in `standard_exception_handling'
/usr/local/lib/ruby/1.9.1/rake/application.rb:63:in `run'
/usr/local/lib/ruby/gems/1.9.1/gems/rake-0.9.2.2/bin/rake:32:in `<top (required)>'
/var/lib/jenkins/.gem/ruby/1.9.1/bin/rake:23:in `load'
/var/lib/jenkins/.gem/ruby/1.9.1/bin/rake:23:in `<main>'
```
