### PR TITLE
Changed deliver_invitation method to use devise notifications

### DIFF
--- a/devise_invitable.gemspec
+++ b/devise_invitable.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   {
     'railties' => '~> 3.0',
     'actionmailer' => '~> 3.0',
-    'devise'   => '>= 2.0.0'
+    'devise'   => '>= 2.1.0'
   }.each do |lib, version|
     s.add_runtime_dependency(lib, *version)
   end

--- a/lib/devise_invitable/model.rb
+++ b/lib/devise_invitable/model.rb
@@ -115,7 +115,7 @@ module Devise
         generate_invitation_token if self.invitation_token.nil?
         self.invitation_sent_at = Time.now.utc
         self.invited_by = invited_by if invited_by
-        
+
         # Call these before_validate methods since we aren't validating on save
         self.downcase_keys if self.new_record? && self.respond_to?(:downcase_keys)
         self.strip_whitespace if self.new_record? && self.respond_to?(:strip_whitespace)
@@ -158,7 +158,7 @@ module Devise
 
         # Deliver the invitation email
         def deliver_invitation
-          ::Devise.mailer.invitation_instructions(self).deliver
+          send_devise_notification(:invitation_instructions)
         end
 
         # Checks if the invitation for the user is within the limit time.


### PR DESCRIPTION
I changed this method because of new method for sending notifications introduced in devise 2.1.0.

Everything works fine and aditionally it works perfect with devise_async gem which allows send devise emails asynchronously. Without that fix, invitation emails are sent normally, without using queue mechanism.

I also bumped devise version in gemspec to >= 2.1.0, because your gem (master) doesn't work with devise < 2.1.0 already.

Thanks for your work, regards,
Szymon
