### PR TITLE
More flexible invitation_fields assignment in RegistrationController

### DIFF
--- a/lib/devise_invitable/controllers/registrations.rb
+++ b/lib/devise_invitable/controllers/registrations.rb
@@ -11,7 +11,7 @@ module DeviseInvitable::Controllers::Registrations
       resource = resource_class.where(:email => hash[:email], :encrypted_password => '').first
       if resource
         @invitation_info = Hash[resource.invitation_fields.map {|field|
-          [field, resource[field]]
+          [field, resource.send(field)]
         }]
         resource.destroy
       end
@@ -31,7 +31,7 @@ module DeviseInvitable::Controllers::Registrations
     resource = resource_class.where(:email => params[resource_name][:email], :invited_by_id => nil).first
     if resource && @invitation_info
       resource.invitation_fields.each do |field|
-        resource[field] = @invitation_info[field]
+        resource.send("#{field}=", @invitation_info[field])
       end
       resource.save!
     end


### PR DESCRIPTION
In our system, when someone invites another user, a join record is creating making those two users collaborators. This can happen in one of two ways, either the invited user exists in the system, or it does not. If the user exists, then they are immediately connected. However, if the user does not exist, the connection is marked as "pending" and an invitation is sent out.

Now, imagine the case in which before accepting the invitation, the invited user came to the app and signed up using the regular devise registrations controller. Devise Invitable handles this by using an around filter that handles destroying the invited user and copying over the "invitation_fields" to the new user.

However, when copying it essentially does this in an around filter:

``` ruby
@invitation_info = Hash[resource.invitation_fields.map {|field|
  [field, resource[field]]
}]

# yield stuff

resource.invitation_fields.each do |field|
  resource[field] = @invitation_info[field]
end
```

I want to be able to add my own attributes to the User model so that they, too, will be copied over to the new user. For example:

``` ruby
class User < ActiveRecord::Base
  # regular devise stuff
  has_many :connections
  has_many :collaborators, :through => :connections

  def invitation_fields
    super << :collaborator_ids
  end
end
```

So, now, it would call `resource.collaborator_ids`, returning, say, `[1,2,3]`. Assigning this to the new users `collaborator_ids` _should_ re-establishing any join records that had been created at the time the previous user was invited. As it currently stands, `resource[field]` and `resource[field]=` are used. This will set the new resource's collaborator_ids to nil, which will prevent the join records from being created.

So, to fix this, my pull request simply uses `resource.send(field)` instead of `resource[field]` in the RegistrationsController.
