### PR TITLE
Don't confirm on invitation, only on accept

### DIFF
--- a/test/models/invitable_test.rb
+++ b/test/models/invitable_test.rb
@@ -334,6 +334,14 @@ class InvitableTest < ActiveSupport::TestCase
     assert !user.valid_password?('new_password')
   end
 
+  test 'should not confirm user on invite' do
+    user = new_user
+
+    user.invite!
+
+    assert !user.confirmed?
+  end
+
   test 'user.has_invitations_left? test' do
     # By default with invitation_limit nil, users can send unlimited invitations
     user = new_user
@@ -405,6 +413,21 @@ class InvitableTest < ActiveSupport::TestCase
     user.username='a'*50
     user.accept_invitation!
     assert_callbacks_not_fired user
+  end
+
+  test 'user.accept_invitation! should confirm user if confirmable' do
+    user = User.invite!(:email => "valid@email.com")
+    user.accept_invitation!
+
+    assert user.confirmed?
+  end
+
+  test 'user.accept_invitation! should not confirm user if validation fails' do
+    user = User.invite!(:email => "valid@email.com")
+    user.username='a'*50
+    user.accept_invitation!
+
+    assert !user.confirmed?
   end
 
   def assert_callbacks_fired(user)


### PR DESCRIPTION
The confirmable model sets the confirmed_at value when you call
skip_confirmation! and this means that a user which has yet to
accept the inviate and considered confirmed.

Instead, I've use hacky workaround so that a new record being invited will
respond with false to confirmation_required? and thereby not sending
a confirmation email on creation.
