### PR TITLE
A malformed post request to create causes error

### DIFF
--- a/lib/devise_invitable/controllers/registrations.rb
+++ b/lib/devise_invitable/controllers/registrations.rb
@@ -28,7 +28,7 @@ module DeviseInvitable::Controllers::Registrations
   def reset_invitation_info
     # Restore info about the last invitation (for later reference)
     # Reset the invitation_info only, if invited_by_id is still nil at this stage:
-    resource = resource_class.where(:email => params[resource_name][:email], :invited_by_id => nil).first
+    resource = resource_class.where(:email => params[resource_name][:email], :invited_by_id => nil).first rescue nil
     if resource && @invitation_info
       resource.invitation_fields.each do |field|
         resource.send("#{field}=", @invitation_info[field])

--- a/test/functional/registrations_controller_test.rb
+++ b/test/functional/registrations_controller_test.rb
@@ -37,14 +37,19 @@ class Devise::RegistrationsControllerTest < ActionController::TestCase
     assert_present @invitee.invited_by_id
     assert_present @invitee.invited_by_type
   end
-  
+
   test "not invitable resources can register" do
     @request.env["devise.mapping"] = Devise.mappings[:admin]
     invitee_email = "invitee@example.org"
-    
+
     post :create, :admin => {:email => invitee_email, :password => "1password"}
-    
+
     @invitee = Admin.where(:email => invitee_email).first
     assert_present @invitee.encrypted_password
+  end
+
+  test "missing params on a create should not cause an error" do
+
+    assert_nothing_raised { post :create }
   end
 end


### PR DESCRIPTION
A malformed post request to create (i.e. missing the email param OR containing a non-existant email) causes the first function to throw an error. 

I've added a rescue nil clause to handle this error and added a test for this. It looks like this may not be used in the edge branch but i thought it might be worthwhile in the meantime. 
