### PR TITLE
Preserve the return value of model#reset_password!

### DIFF
--- a/lib/devise_invitable/model.rb
+++ b/lib/devise_invitable/model.rb
@@ -146,8 +146,9 @@ module Devise
       end
 
       def reset_password!(new_password, new_password_confirmation)
-        super
+        result = super
         accept_invitation!
+        return result
       end
 
       def invite_key_valid?

--- a/test/models/invitable_test.rb
+++ b/test/models/invitable_test.rb
@@ -497,4 +497,10 @@ class InvitableTest < ActiveSupport::TestCase
     assert_equal 1, User.invitation_not_accepted.count
     assert_equal 1, User.invitation_accepted.count
   end
+
+  test "should preserve return values of Devise::Recoverable#reset_password!" do
+    user = new_user
+    retval = user.reset_password!('anewpassword', 'anewpassword')
+    assert_equal true, retval
+  end
 end


### PR DESCRIPTION
Per the docs for `Devise::Recoverable`, `#reset_password!` should return
true or false: http://rubydoc.info/github/plataformatec/devise/master/Devise/Models/Recoverable#reset_password%21-instance_method

(fixed an extra test line in the previous PR)
