### PR TITLE
Accept invitation when resetting password only if invited

### DIFF
--- a/lib/devise_invitable/model.rb
+++ b/lib/devise_invitable/model.rb
@@ -147,7 +147,7 @@ module Devise
 
       def after_password_reset
         super
-        accept_invitation!
+        accept_invitation! if invited_to_sign_up?
       end
 
       def invite_key_valid?

--- a/test/models/invitable_test.rb
+++ b/test/models/invitable_test.rb
@@ -164,6 +164,17 @@ class InvitableTest < ActiveSupport::TestCase
     assert user.invited_to_sign_up?
   end
 
+  test 'should not set invitation_accepted_at if just resetting password' do
+    user = User.create!(:email => "valid@email.com", :password => "123456780")
+    assert !user.invited_to_sign_up?
+    user.send(:generate_reset_password_token!)
+    assert_present user.reset_password_token
+    assert_nil user.invitation_token
+    User.reset_password_by_token(:reset_password_token => user.reset_password_token, :password => '123456789', :password_confirmation => '123456789')
+    assert_nil user.reload.invitation_token
+    assert_nil user.reload.invitation_accepted_at
+  end
+
   test 'should reset invitation token and send invitation by email' do
     user = new_user
     assert_difference('ActionMailer::Base.deliveries.size') do


### PR DESCRIPTION
Currently `invitation_accepted_at` is set any time any user resets their password.
This checks to make sure there is an outstanding invitation before calling `accept_invitation!`
