### PR TITLE
Require Devise 2.1.1

### DIFF
--- a/devise_invitable.gemspec
+++ b/devise_invitable.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   {
     'railties' => '~> 3.0',
     'actionmailer' => '~> 3.0',
-    'devise'   => '>= 2.1.0'
+    'devise'   => '>= 2.1.1'
   }.each do |lib, version|
     s.add_runtime_dependency(lib, *version)
   end


### PR DESCRIPTION
Bumping minimum Devise version from 2.1.0 to 2.1.1 because 2.1.0 doesn't have the send_devise_notification method used to send invitation emails.
