### PR TITLE
Ensure invitation_accepted_at is set later to enable conditional validations

### DIFF
--- a/lib/devise_invitable/model.rb
+++ b/lib/devise_invitable/model.rb
@@ -73,8 +73,8 @@ module Devise
       # Accept an invitation by clearing invitation token and and setting invitation_accepted_at
       # Confirms it if model is confirmable
       def accept_invitation!
-        self.invitation_accepted_at = Time.now.utc
         if self.invited_to_sign_up? && self.valid?
+          self.invitation_accepted_at = Time.now.utc
           run_callbacks :invitation_accepted do
             self.invitation_token = nil
             self.confirmed_at = self.invitation_accepted_at if self.respond_to?(:confirmed_at)

--- a/test/models/invitable_test.rb
+++ b/test/models/invitable_test.rb
@@ -497,6 +497,7 @@ class InvitableTest < ActiveSupport::TestCase
     user = User.invite!(:email => "valid@email.com")
     user.username = 'test'
     user.testing_accepting_or_not_invited = true
+    user.bio = "Test"
     user.accept_invitation!
     assert_equal true, user.valid?
   end

--- a/test/rails_app/app/models/user.rb
+++ b/test/rails_app/app/models/user.rb
@@ -32,11 +32,12 @@ class User < PARENT_MODEL_CLASS
   devise :database_authenticatable, :registerable, :validatable, :confirmable, :invitable, :recoverable
 
   attr_accessible :email, :username, :password, :password_confirmation, :skip_invitation
-  attr_accessor :callback_works, :before_observer_callback_works, :after_observer_callback_works
+  attr_accessor :callback_works, :before_observer_callback_works, :after_observer_callback_works, :bio
   validates :username, :length => { :maximum => 20 }
   
   attr_accessor :testing_accepting_or_not_invited
   validates :username, :presence => true, :if => :testing_accepting_or_not_invited_validator?
+  validates :bio, :presence => true, :if => :invitation_accepted?
 
   def testing_accepting_or_not_invited_validator?
     testing_accepting_or_not_invited && accepting_or_not_invited?


### PR DESCRIPTION
This way we can define a validation in terms of wether the user has accepted
the invitation or not:

``` Ruby
validate :bio, if: :invitation_accepted?
```
