### PR TITLE
Remove changing password_salt field

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -67,8 +67,6 @@ or for a model that already exists, define a migration to add DeviseInvitable to
 
   # Allow null encrypted_password
   change_column :users, :encrypted_password, :string, :null => true
-  # Allow null password_salt (add it if you are using Devise's encryptable module)
-  change_column :users, :password_salt, :string, :null => true
 
 == Model configuration
 


### PR DESCRIPTION
There's no password_salt since devise 1.2.1:

"Devise 1.2.1 does not require a password_salt column anymore if you 
are using bcrypt. If you need a kind of salt, I believe there is a 
method called authentication_salt you could use to retrieve such 
values." ~ Jose Valim (https://groups.google.com/d/msg/plataformatec-devise/saHGSLwm5U0/GCQ1PkOh8AUJ)
