### PR TITLE
proposed change to enable invites to be sent to new_users

### DIFF
--- a/lib/devise_invitable/model.rb
+++ b/lib/devise_invitable/model.rb
@@ -152,8 +152,10 @@ module Devise
 
       def invite_key_valid?
         return true unless self.class.invite_key.is_a? Hash # FIXME: remove this line when deprecation is removed
-        self.class.invite_key.all? do |key, regexp|
-          regexp.nil? || self.send(key).try(:match, regexp)
+        if self.class.invite_key.all? 
+          self.class.invite_key do |key, regexp|
+            regexp.nil? || self.send(key).try(:match, regexp)
+          end
         end
       end
 


### PR DESCRIPTION
Could not send invitations from the rails console according to the usage instructions:  

User.invite!( { :email => 'john.doe@example.com' } )

I poked around, and invite_key_valid was returning false, and the problem seemed to be:

self.class.invite_key.all? do |key, regexp|

self.class.invite_key.all? returned a boolean, not a hash, which seemed to be expected.  After making this change, I could send invitations for new users without issue.  
