### PR TITLE
Add conditional validation support for resource model

### DIFF
--- a/lib/devise_invitable.rb
+++ b/lib/devise_invitable.rb
@@ -31,6 +31,16 @@ module Devise
   mattr_accessor :validate_on_invite
   @@validate_on_invite = false
 
+  # Public: Flag that allow conditional validation of the model during the
+  # invitation creation phase.
+  # (default: false).
+  #
+  # Examples (in config/initializers/devise.rb)
+  #
+  #   config.validate_on_invite = true
+  mattr_accessor :conditional_validation_on_invite
+  @@conditional_validation_on_invite = false
+
   # Public: number of invitations the user is allowed to send
   #
   # Examples (in config/initializers/devise.rb)

--- a/lib/devise_invitable/model.rb
+++ b/lib/devise_invitable/model.rb
@@ -24,6 +24,7 @@ module Devise
       extend ActiveSupport::Concern
 
       attr_accessor :skip_invitation
+      attr_accessor :invite_conditional_validation
       attr_accessor :completing_invite
 
       included do
@@ -158,6 +159,11 @@ module Devise
       end
 
       protected
+
+        def invite_conditional_validation?
+          @invite_conditional_validation
+        end
+
         # Overriding the method in Devise's :validatable module so password is not required on inviting
         def password_required?
           !@skip_password && super
@@ -226,6 +232,7 @@ module Devise
           invitable.invited_by = invited_by
 
           invitable.skip_password = true
+          invitable.invite_conditional_validation = self.conditional_validation_on_invite
           invitable.valid? if self.validate_on_invite
           if invitable.new_record?
             invitable.errors.clear if !self.validate_on_invite and invitable.invite_key_valid?
@@ -290,6 +297,7 @@ module Devise
 
         Devise::Models.config(self, :invite_for)
         Devise::Models.config(self, :validate_on_invite)
+        Devise::Models.config(self, :conditional_validation_on_invite)
         Devise::Models.config(self, :invitation_limit)
         Devise::Models.config(self, :invite_key)
         Devise::Models.config(self, :resend_invitation)

--- a/lib/generators/devise_invitable/install_generator.rb
+++ b/lib/generators/devise_invitable/install_generator.rb
@@ -43,6 +43,18 @@ module DeviseInvitable
   # Default: false
   # config.validate_on_invite = true
 
+  # Flag that enables possibility of conditional validation of the invitee resource
+  # model. Use in conjuction with the flag validate_on_invite set to true.
+  #
+  # Example:
+  #
+  # class User
+  #   validates :username, prensence: true, unless: :invite_conditional_validation?
+  # end
+  #
+  # Default: false
+  # config.conditional_validation_on_invite = true
+
 CONTENT
             end
           end


### PR DESCRIPTION
This patch enables conditional validation during the invitation creation phase for the invitee resource.

It adds flag `conditional_validation_on_invite` which enables possibility of conditional validation of the invitee resource via the `invite_conditional_validation?` method.

**initializers/devise.rb**

``` ruby
config.invite_key = {firstname: nil, lastname: nil, email: nil}
config.validate_on_invite = true
config.conditional_validation_on_invite = true
```

**models/user.rb**

``` ruby
class User
  validates :username, presence: true, unless: :invite_conditional_validation?
  validates :firstname, :lastname, presence: true, length: { minimum: 2, maximum: 30 }
  validates :email, email_format: { message: 'is not looking good' }
end
```

For more about my motivation see my comment at https://github.com/scambra/devise_invitable/issues/280#issuecomment-13684564
