### PR TITLE
Made invites use :updated_not_active on accept

### DIFF
--- a/app/controllers/devise/invitations_controller.rb
+++ b/app/controllers/devise/invitations_controller.rb
@@ -38,7 +38,8 @@ class Devise::InvitationsController < DeviseController
     self.resource = resource_class.accept_invitation!(resource_params)
 
     if resource.errors.empty?
-      set_flash_message :notice, :updated
+      flash_message = resource.active_for_authentication? ? :updated : :updated_not_active                                                                                        
+      set_flash_message :notice, flash_message
       sign_in(resource_name, resource)
       respond_with resource, :location => after_accept_path_for(resource)
     else


### PR DESCRIPTION
Devise defines an updated flash message, and also an updated_not_active message. It uses this when updating the user's password (see PasswordsController#update)
