### PR TITLE
Mass assignment for accepting invites

### DIFF
--- a/lib/devise_invitable/model.rb
+++ b/lib/devise_invitable/model.rb
@@ -267,7 +267,7 @@ module Devise
           invitable = find_or_initialize_with_error_by(:invitation_token, attributes.delete(:invitation_token))
           invitable.errors.add(:invitation_token, :invalid) if invitable.invitation_token && invitable.persisted? && !invitable.valid_invitation?
           if invitable.errors.empty?
-            invitable.attributes = attributes
+            invitable.assign_attributes(attributes, :as => inviter_role(self))
             invitable.accept_invitation!
           end
           invitable


### PR DESCRIPTION
In [invites#update](https://github.com/scambra/devise_invitable/blob/master/app/controllers/devise/invitations_controller.rb#L38), `accept_invitation!` is called with potentially unsafe user input. The current definition uses the `:default` role from [ActiveModel's MassAssignmentSecurity module](http://api.rubyonrails.org/classes/ActiveModel/MassAssignmentSecurity/ClassMethods.html), but does not allow an override.

I noticed that [`.inviter_role`](https://github.com/scambra/devise_invitable/blob/master/lib/devise_invitable/model.rb#L245-L249) is overridable and used by `.invite!`. This pull reuses `.inviter_role`, but it overloads the meaning the method. Would it make more sense to have a similar, but more general override for devise_invitable related saves? Perhaps a method like `.devise_mass_assignment_role`?
