### PR TITLE
fix for the migration template

### DIFF
--- a/lib/generators/active_record/templates/migration.rb
+++ b/lib/generators/active_record/templates/migration.rb
@@ -6,7 +6,7 @@ class DeviseInvitableAddTo<%= table_name.camelize %> < ActiveRecord::Migration
       t.datetime   :invitation_accepted_at
       t.integer    :invitation_limit
       t.references :invited_by, :polymorphic => true
-      t.index      :invitation_token # for invitable
+      t.index      :invitation_token, :unique => true # for invitable
       t.index      :invited_by_id
     end
 


### PR DESCRIPTION
The test app have unique token index but not the mig template. Is unique maybe unsupported in some versions or is this just an typo?
