### PR TITLE
Make #respond_to? calls compatible with Ruby 2.0.0

### DIFF
--- a/lib/devise_invitable/model.rb
+++ b/lib/devise_invitable/model.rb
@@ -124,7 +124,7 @@ module Devise
 
         # Required to workaround confirmable model's confirmation_required? method
         # being implemented to check for non-nil value of confirmed_at
-        if self.new_record? && self.respond_to?(:confirmation_required?)
+        if self.new_record? && self.respond_to?(:confirmation_required?, true)
           def self.confirmation_required?; false; end
         end
 
@@ -133,8 +133,8 @@ module Devise
         self.invited_by = invited_by if invited_by
 
         # Call these before_validate methods since we aren't validating on save
-        self.downcase_keys if self.new_record? && self.respond_to?(:downcase_keys)
-        self.strip_whitespace if self.new_record? && self.respond_to?(:strip_whitespace)
+        self.downcase_keys if self.new_record? && self.respond_to?(:downcase_keys, true)
+        self.strip_whitespace if self.new_record? && self.respond_to?(:strip_whitespace, true)
 
         if save(:validate => false)
           self.invited_by.decrement_invitation_limit! if !was_invited and self.invited_by.present?
@@ -173,7 +173,7 @@ module Devise
         end
 
         def confirmation_required_for_invited?
-          respond_to?(:confirmation_required?) && confirmation_required? && invitation_accepted?
+          respond_to?(:confirmation_required?, true) && confirmation_required? && invitation_accepted?
         end
 
         # Deliver the invitation email


### PR DESCRIPTION
I'm not sure if you're officially supporting Ruby 2.0.0 yet, but this will help when you do.

devise_invitable relies on respond_to? to decide when to override methods such as #confirmation_required? that may be defined by other Devise modules. In Ruby 2.0, #respond_to? returns false for protected methods unless you pass true as a second method argument. This change in behavior caused 6 test breaks, including delivery of confirmation instructions email after calling #invite! 

Tested with MRI Ruby 1.9.3-p392 and 2.0.0-p0 against mongoid (rake test DEVISE_ORM=mongoid).
