### PR TITLE
Add invitation_token to whitelist

### DIFF
--- a/lib/devise_invitable/parameter_sanitizer.rb
+++ b/lib/devise_invitable/parameter_sanitizer.rb
@@ -5,7 +5,7 @@ module DeviseInvitable
     end
 
     def accept_invitation
-      default_params.permit([:password, :password_confirmation])
+      default_params.permit([:password, :password_confirmation, :invitation_token])
     end
   end
 end


### PR DESCRIPTION
Before:

```
1) Failure:
InvitationTest#test_after_entering_invalid_data_user_should_still_be_able_to_set_his_password [/home/lite/work/devise_invitable/test/integration/invitation_test.rb:105]:
Failed assertion, no message given.

  2) Failure:
InvitationTest#test_not_authenticated_user_with_valid_data_should_be_able_to_change_his_password [/home/lite/work/devise_invitable/test/integration/invitation_test.rb:90]:
Expected: "/"
  Actual: "/users/invitation"

  3) Failure:
InvitationTest#test_not_authenticated_user_with_valid_invitation_token_but_invalid_password_should_not_be_able_to_set_his_password [/home/lite/work/devise_invitable/test/integration/invitation_test.rb:82]:
Failed assertion, no message given.

  4) Failure:
InvitationTest#test_sign_in_user_automatically_after_setting_it's_password [/home/lite/work/devise_invitable/test/integration/invitation_test.rb:112]:
Expected: "/"
  Actual: "/users/invitation"
```

After

```
................................................................................................................

Finished tests in 11.147882s, 10.0468 tests/s, 23.1434 assertions/s.

112 tests, 258 assertions, 0 failures, 0 errors, 0 skips

```
