### PR TITLE
Added ability to use with rails 4.1.0.beta and actionmailer (4.1.0.beta)

### DIFF
--- a/devise_invitable.gemspec
+++ b/devise_invitable.gemspec
@@ -21,8 +21,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency('bundler', '>= 1.1.0')
 
   {
-    'railties' => '~> 4.0.0.beta',
-    'actionmailer' => '~> 4.0.0.beta',
+    'railties' => '>= 4.0.0.beta',
+    'actionmailer' => '>= 4.0.0.beta',
     #'devise'   => '>= 2.1.2'
   }.each do |lib, version|
     s.add_runtime_dependency(lib, *version)


### PR DESCRIPTION
```
In Gemfile:
    devise_invitable (>= 0) ruby depends on
      actionmailer (~> 4.0.0.beta) ruby

    rails (>= 0) ruby depends on
      actionmailer (4.1.0.beta)
```
