### PR TITLE
Unscope invitable resource lookup

### DIFF
--- a/app/controllers/devise/invitations_controller.rb
+++ b/app/controllers/devise/invitations_controller.rb
@@ -64,7 +64,7 @@ class Devise::InvitationsController < DeviseController
   end
   
   def resource_from_invitation_token
-    unless params[:invitation_token] && self.resource = resource_class.to_adapter.find_first(params.slice(:invitation_token))
+    unless params[:invitation_token] && self.resource = resource_class.unscoped.find_by_invitation_token(params[:invitation_token])
       set_flash_message(:alert, :invitation_token_invalid)
       redirect_to after_sign_out_path_for(resource_name)
     end


### PR DESCRIPTION
Fixes an issue where looking up resource by invitation token used default scope for that model. Now uses unscoped model.

Fixes #320
