### PR TITLE
Sync up with Devise 3 dependencies

### DIFF
--- a/devise_invitable.gemspec
+++ b/devise_invitable.gemspec
@@ -21,12 +21,6 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency('bundler', '>= 1.1.0')
 
-  {
-    'railties' => '~> 3.0',
-    'actionmailer' => '~> 3.0',
-    'devise'   => '>= 3.0.0.rc'
-  }.each do |lib, version|
-    s.add_runtime_dependency(lib, *version)
-  end
-
+  s.add_runtime_dependency('actionmailer', '>= 3.2.6', '< 5')
+  s.add_runtime_dependency('devise', '>= 3.0.0.rc')
 end


### PR DESCRIPTION
- allow Rails 4
- require at least Rails 3.2
- skip railties dependency that Devise already has
