### PR TITLE
includes hash params to super.build_resource method call to avoid issues

### DIFF
--- a/app/controllers/devise_invitable/registrations_controller.rb
+++ b/app/controllers/devise_invitable/registrations_controller.rb
@@ -10,6 +10,6 @@ class DeviseInvitable::RegistrationsController < Devise::RegistrationsController
         self.resource.accept_invitation
       end
     end
-    self.resource ||= super
+    self.resource ||= super(hash)
   end
 end


### PR DESCRIPTION
if [build_resource L13](https://github.com/scambra/devise_invitable/blob/master/app/controllers/devise_invitable/registrations_controller.rb#L13) calls to super, no params is sent, so if it tries to build_resource for sign_up it will fail because the form params wont't be sent
