### PR TITLE
Added missing :invitation_created_at in the down migration.

### DIFF
--- a/lib/generators/active_record/templates/migration.rb
+++ b/lib/generators/active_record/templates/migration.rb
@@ -21,7 +21,7 @@ class DeviseInvitableAddTo<%= table_name.camelize %> < ActiveRecord::Migration
   def down
     change_table :<%= table_name %> do |t|
       t.remove_references :invited_by, :polymorphic => true
-      t.remove :invitation_limit, :invitation_sent_at, :invitation_accepted_at, :invitation_token
+      t.remove :invitation_limit, :invitation_sent_at, :invitation_accepted_at, :invitation_token, :invitation_created_at
     end
   end
 end


### PR DESCRIPTION
When rolling back the migration, the :invitation_created_at field does not get removed from the table, since it was missing from the `down` method.
