### PR TITLE
In InvitationsController, extract resource invitation into its own method

### DIFF
--- a/app/controllers/devise/invitations_controller.rb
+++ b/app/controllers/devise/invitations_controller.rb
@@ -14,7 +14,7 @@ class Devise::InvitationsController < DeviseController
 
   # POST /resource/invitation
   def create
-    self.resource = resource_class.invite!(invite_params, current_inviter)
+    self.resource = invite_resource
 
     if resource.errors.empty?
       set_flash_message :notice, :send_instructions, :email => self.resource.email if self.resource.invitation_sent_at
@@ -51,6 +51,11 @@ class Devise::InvitationsController < DeviseController
   end
 
   protected
+
+  def invite_resource
+    resource_class.invite!(invite_params, current_inviter)
+  end
+
   def current_inviter
     @current_inviter ||= authenticate_inviter!
   end


### PR DESCRIPTION
This is just a small change to make it possible for a subclass to override how the resource is created (e.g. by passing a block to `resource.invite!`) without needing to override the entire `create` method.
