### PR TITLE
Make devise dependency soft dependable

### DIFF
--- a/devise_invitable.gemspec
+++ b/devise_invitable.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency('bundler', '>= 1.1.0')
 
   s.add_runtime_dependency('actionmailer', '>= 3.2.6', '< 5')
-  s.add_runtime_dependency('devise', '~> 3.0.0')
+  s.add_runtime_dependency('devise', '>= 3.0.0')
 end


### PR DESCRIPTION
Make devise dependency soft dependable to allow devise above 3.0 instead of just 3.0.0
