### PR TITLE
Don't send email if _invite callback invalidates record

### DIFF
--- a/lib/devise_invitable/model.rb
+++ b/lib/devise_invitable/model.rb
@@ -246,7 +246,7 @@ module Devise
 
           if invitable.errors.empty?
             yield invitable if block_given?
-            mail = invitable.invite!
+            mail = invitable.invite! if invitable.errors.empty?
           end
           [invitable, mail]
         end


### PR DESCRIPTION
Caller should be able to abort the email once the resource is created.
