### PR TITLE
Don't rewrite invited_by_id by another user

### DIFF
--- a/lib/devise_invitable/model.rb
+++ b/lib/devise_invitable/model.rb
@@ -238,7 +238,7 @@ module Devise
           invitable.valid? if self.validate_on_invite
           if invitable.new_record?
             invitable.errors.clear if !self.validate_on_invite and invitable.invite_key_valid?
-          elsif !invitable.invited_to_sign_up? || !self.resend_invitation
+          elsif !invitable.invited_to_sign_up? || !self.resend_invitation || invitable.invited_by_id_changed?
             invite_key_array.each do |key|
               invitable.errors.add(key, :taken)
             end

--- a/test/models/invitable_test.rb
+++ b/test/models/invitable_test.rb
@@ -544,4 +544,15 @@ class InvitableTest < ActiveSupport::TestCase
     retval = user.reset_password!('anewpassword', 'anewpassword')
     assert_equal true, retval
   end
+
+  test "should not rewrite invited_by_id if another user send invite with the existing email" do
+    invited_email = "valid@email.com"
+    first_inviter = new_user
+    User.invite!({:email => invited_email}, first_inviter)
+
+    second_inviter = new_user
+    User.invite!({:email => invited_email}, second_inviter)
+
+    assert_equal first_inviter.id, User.where(:email => invited_email).first.invited_by_id
+  end
 end


### PR DESCRIPTION
Hi!
I faced up with following problem:
- First user create an invitation. This invitation will attached to him
- Second user create an invitation with the same email like the first user. invitation_by_id will rewriting with the second user, but it shouldn't

I think this is a bug and I've attached test+code 
