### PR TITLE
pass extra context to invitation email by using a custom Devise::Mailer ...

### DIFF
--- a/lib/devise_invitable/model.rb
+++ b/lib/devise_invitable/model.rb
@@ -25,7 +25,8 @@ module Devise
 
       attr_accessor :skip_invitation
       attr_accessor :completing_invite
-
+      attr_accessor :invitation_context # hash
+      
       included do
         include ::DeviseInvitable::Inviter
         if Devise.invited_by_class_name
@@ -155,7 +156,7 @@ module Devise
       def deliver_invitation
         generate_invitation_token! unless @raw_invitation_token
         self.update_attribute :invitation_sent_at, Time.now.utc unless self.invitation_sent_at
-        send_devise_notification(:invitation_instructions, @raw_invitation_token)
+        send_devise_notification(:invitation_instructions, @raw_invitation_token, @invitation_context || {})
       end
 
       protected


### PR DESCRIPTION
...and changes to devise_invitable/model.rb

Pass additional context to :invitation_instructions that use *args from recent send_devise_notifications. These changes are needed to work with devise-async to pass down extra parameters when they can't be persisted (attr_accessor on user).

Example implementation:
https://gist.github.com/bruchu/6889955
