### PR TITLE
values for the invite key hash can be anything that responds to the === operator

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -124,7 +124,7 @@ or directly as parameters to the <tt>devise</tt> method:
 
 * invitation_limit: The number of invitations users can send.  The default value of nil means users can send as many invites as they want, there is no limit for any user, invitation_limit column is not used.  A setting of 0 means they can't send invitations.  A setting n > 0 means they can send n invitations. You can change invitation_limit column for some users so they can send more or less invitations, even with global invitation_limit = 0.
 
-* invite_key: The key to be used to check existing users when sending an invitation. You can use multiple keys. This value must be a hash with the invite key as hash keys, and regexp to validate format as values. If you don't want to validate the key you can set nil as validation format. The default value is looking for users by email and validating with Devise.email_regexp {:email => Devise.email_regexp}.
+* invite_key: The key to be used to check existing users when sending an invitation. You can use multiple keys. This value must be a hash with the invite key as hash keys, and values that respond to the === operator(includes procs and regexes). The default value is looking for users by email and validating with Devise.email_regexp {:email => Devise.email_regexp}.
 
 * validate_on_invite: force a record to be valid before being actually invited.
 

--- a/lib/devise_invitable/model.rb
+++ b/lib/devise_invitable/model.rb
@@ -146,8 +146,8 @@ module Devise
       end
 
       def clear_errors_on_valid_keys
-        self.class.invite_key.each do |key, regexp|
-          self.errors.delete(key) if regexp.nil? || self.send(key).try(:match, regexp)
+        self.class.invite_key.each do |key, value|
+          self.errors.delete(key) if value === self.send(key)
         end
       end
 
@@ -221,7 +221,9 @@ module Devise
           invite_key_array = invite_key_fields
           attributes_hash = {}
           invite_key_array.each do |k,v|
-            attributes_hash[k] = attributes.delete(k).to_s.strip
+            attribute = attributes.delete(k)
+            attribute = attribute.to_s.strip if strip_whitespace_keys.include?(k)
+            attributes_hash[k] = attribute
           end
 
           invitable = find_or_initialize_with_errors(invite_key_array, attributes_hash)

--- a/test/rails_app/app/models/user.rb
+++ b/test/rails_app/app/models/user.rb
@@ -26,8 +26,10 @@ class User < PARENT_MODEL_CLASS
     field :invited_by_id,          :type => Integer
     field :invited_by_type,        :type => String
 
-
     field :username
+    field :profile_id
+    field :active
+
     validates_presence_of :email
     validates_presence_of :encrypted_password, :if => :password_required?
   end

--- a/test/rails_app/db/migrate/20100401102949_create_tables.rb
+++ b/test/rails_app/db/migrate/20100401102949_create_tables.rb
@@ -16,6 +16,8 @@ class CreateTables < ActiveRecord::Migration
       t.string   :unconfirmed_email # Only if using reconfirmable
 
       t.string :username
+      t.integer :profile_id
+      t.boolean :active
 
       ## Invitable
       t.string   :invitation_token, :limit => 60


### PR DESCRIPTION
This allows for any additional fields you wish to be validated upon invite. I also removed the nil check since the only time this method is called is if validate_on_invite is false and in that case specifying an attribute as an invite key only to allow it to be nil seems pointless unless I'm missing something.
