### PR TITLE
#392 - provide standard interface for raw and encrypted tokens

### DIFF
--- a/lib/devise_invitable/model.rb
+++ b/lib/devise_invitable/model.rb
@@ -25,6 +25,7 @@ module Devise
 
       attr_accessor :skip_invitation
       attr_accessor :completing_invite
+      attr_reader   :raw_invitation_token
 
       included do
         include ::DeviseInvitable::Inviter
@@ -158,6 +159,11 @@ module Devise
         send_devise_notification(:invitation_instructions, @raw_invitation_token)
       end
 
+      # provide alias to the encrypted invitation_token stored by devise
+      def encrypted_invitation_token
+        self.invitation_token
+      end
+
       protected
         # Overriding the method in Devise's :validatable module so password is not required on inviting
         def password_required?
@@ -272,7 +278,7 @@ module Devise
 
         def find_by_invitation_token(original_token, only_valid)
           invitation_token = Devise.token_generator.digest(self, :invitation_token, original_token)
-          
+
           invitable = find_or_initialize_with_error_by(:invitation_token, invitation_token)
           if !invitable.persisted? && Devise.allow_insecure_token_lookup
             invitable = find_or_initialize_with_error_by(:invitation_token, original_token)

--- a/test/models/invitable_test.rb
+++ b/test/models/invitable_test.rb
@@ -11,6 +11,10 @@ class InvitableTest < ActiveSupport::TestCase
     assert_nil new_user.invitation_token
   end
 
+  test 'should not generate the raw invitation token after creating a record' do
+    assert_nil new_user.raw_invitation_token
+  end
+
   test 'should regenerate invitation token each time' do
     user = new_user
     user.invite!
@@ -23,6 +27,21 @@ class InvitableTest < ActiveSupport::TestCase
       assert_not_equal token, user.invitation_token
       token = user.invitation_token
     end
+  end
+
+  test 'should alias the invitation_token method with encrypted_invitation_token' do
+    user = new_user
+    user.invite!
+    assert_equal user.invitation_token, user.encrypted_invitation_token
+  end
+
+  test 'should return the correct raw_invitation_token ' do
+    user = new_user
+    raw, enc = Devise.token_generator.generate(user.class, :invitation_token)
+    #stub the generator so the tokens are the same
+    Devise.token_generator.stubs(:generate).returns([raw, enc])
+    user.invite!
+    assert_equal user.raw_invitation_token, raw
   end
 
   test 'should set invitation created and sent at each time' do

--- a/test/models_test.rb
+++ b/test/models_test.rb
@@ -70,5 +70,9 @@ class ModelsTest < ActiveSupport::TestCase
   test 'invitable attributes' do
     assert_nil User.new.invitation_token
     assert_nil User.new.invitation_sent_at
+    #raw token
+    assert_nil User.new.raw_invitation_token
+    #encrypted token - alias to invitation token
+    assert_nil User.new.encrypted_invitation_token
   end
 end


### PR DESCRIPTION
Standardise access to the invited model's raw and encrypted tokens due to devise now only storing encrypted tokens in the database.
