### PR TITLE
Splat the arguments to strong_parameters#permit, fixes strong_parameters gem support

### DIFF
--- a/lib/devise_invitable/parameter_sanitizer.rb
+++ b/lib/devise_invitable/parameter_sanitizer.rb
@@ -1,11 +1,11 @@
 module DeviseInvitable
   module ParameterSanitizer
     def invite
-      default_params.permit self.for(:invite)
+      permit self.for(:invite)
     end
 
     def accept_invitation
-      default_params.permit self.for(:accept_invitation)
+      permit self.for(:accept_invitation)
     end
 
     def self.included(base)
@@ -13,6 +13,10 @@ module DeviseInvitable
     end
 
     private
+    def permit(keys)
+      default_params.permit(*Array(keys))
+    end
+
     def attributes_for_with_invitable(kind)
       case kind
       when :invite


### PR DESCRIPTION
Fixes devise_invitable to work exactly the same way as devise now does, which fixes strong_parameters gem support, and also works exactly the same in rails4.

See here for the related devise issue:
plataformatec/devise#2716

See here for the related devise commits:
plataformatec/devise@e445039716c3397e0ef286257bb9bfffe93f2d67
