### PR TITLE
confirmation emails get sent inifinitely when an invited user signs up

### DIFF
--- a/app/controllers/devise_invitable/registrations_controller.rb
+++ b/app/controllers/devise_invitable/registrations_controller.rb
@@ -7,6 +7,7 @@ class DeviseInvitable::RegistrationsController < Devise::RegistrationsController
       self.resource = resource_class.where(:email => hash[:email], :encrypted_password => '').first
       if self.resource
         self.resource.attributes = hash
+        self.resource.send_confirmation_instructions if self.resource.confirmation_required_for_invited?
         self.resource.accept_invitation
       end
     end

--- a/lib/devise_invitable/model.rb
+++ b/lib/devise_invitable/model.rb
@@ -37,8 +37,6 @@ module Devise
 
         include ActiveSupport::Callbacks
         define_callbacks :invitation_accepted
-        before_update :generate_confirmation_token, :if => :confirmation_required_for_invited?
-        after_update :send_invited_confirmation_instructions, :if => :confirmation_required_for_invited?
 
         attr_writer :skip_password
 
@@ -164,9 +162,8 @@ module Devise
         self.invitation_token
       end
 
-      def send_invited_confirmation_instructions
-        send_confirmation_instructions
-        @confirmation_sent_at = Time.now
+      def confirmation_required_for_invited?
+        respond_to?(:confirmation_required?, true) && confirmation_required?
       end
 
       protected
@@ -175,10 +172,7 @@ module Devise
           !@skip_password && super
         end
 
-        def confirmation_required_for_invited?
-          respond_to?(:confirmation_required?, true) && confirmation_required? && invitation_accepted? && @confirmation_sent_at.blank?
-        end
-
+        
         # Checks if the invitation for the user is within the limit time.
         # We do this by calculating if the difference between today and the
         # invitation sent date does not exceed the invite for time configured.

--- a/test/functional/registrations_controller_test.rb
+++ b/test/functional/registrations_controller_test.rb
@@ -34,8 +34,8 @@ class DeviseInvitable::RegistrationsControllerTest < ActionController::TestCase
 
     @invitee = User.where(:email => invitee_email).first
 
-    # only one confirmation email gets sent
-    assert_difference('ActionMailer::Base.deliveries.size', 1) do
+    # do not send emails on model changes
+    assert_difference('ActionMailer::Base.deliveries.size', 0) do
       @invitee.bio = "I am a robot"
       @invitee.save!
       @invitee.bio = "I am a human"


### PR DESCRIPTION
the commit: https://github.com/scambra/devise_invitable/commit/51cd0485c6dec323e9456c6266f43e9c14a5d1e8#diff-c4d29d16cf6c6cb74d6523498cd0d88fR39

results in a confirmation email being sent with every update to the user model. Since generation a confirmation updates the user model, it ends up being sent in an infinite loop!

This pull request fixes the issue by checking if @confirmation_sent_at is present so that only one email gets sent.
