### PR TITLE
Remove invitations_count on inviteable drop

### DIFF
--- a/lib/generators/active_record/templates/migration.rb
+++ b/lib/generators/active_record/templates/migration.rb
@@ -23,7 +23,7 @@ class DeviseInvitableAddTo<%= table_name.camelize %> < ActiveRecord::Migration
   def down
     change_table :<%= table_name %> do |t|
       t.remove_references :invited_by, :polymorphic => true
-      t.remove :invitation_limit, :invitation_sent_at, :invitation_accepted_at, :invitation_token, :invitation_created_at
+      t.remove :invitations_count, :invitation_limit, :invitation_sent_at, :invitation_accepted_at, :invitation_token, :invitation_created_at
     end
   end
 end


### PR DESCRIPTION
invitations_count wasn't removed when rolling back the inviteable migration
