### PR TITLE
pass block from invite_resource to invite!

### DIFF
--- a/app/controllers/devise/invitations_controller.rb
+++ b/app/controllers/devise/invitations_controller.rb
@@ -55,8 +55,8 @@ class Devise::InvitationsController < DeviseController
 
   protected
 
-  def invite_resource
-    resource_class.invite!(invite_params, current_inviter)
+  def invite_resource(&block)
+    resource_class.invite!(invite_params, current_inviter, &block)
   end
   
   def accept_resource


### PR DESCRIPTION
Devise::Models::Invitable#invite! yields, which is very useful for validating certain attributes of the invitation without enabling full validation of invited users.  However, that block wasn't actually being passed from Devise::InvitationsController#invite_resource, so in order to take advantage of the yield in invite!, my subclass of Devise::InvitationsController has to override both the create action and invite_resource.  With this pull request, I just have to override the create action and add your block as follows:

``` ruby
def create
  self.resource = invite_resource do |invitable|
    add_some_errors_if_necessary
  end
.
.
.
```
