### PR TITLE
fixing nil reference in invitations_controller.rb

### DIFF
--- a/app/controllers/devise/invitations_controller.rb
+++ b/app/controllers/devise/invitations_controller.rb
@@ -27,6 +27,7 @@ class Devise::InvitationsController < DeviseController
 
   # GET /resource/invitation/accept?invitation_token=abcdef
   def edit
+    self.resource = @resource
     resource.invitation_token = params[:invitation_token]
     render :edit
   end
@@ -48,6 +49,7 @@ class Devise::InvitationsController < DeviseController
   
   # GET /resource/invitation/remove?invitation_token=abcdef
   def destroy
+    self.resource = @resource
     resource.destroy
     set_flash_message :notice, :invitation_removed
     redirect_to after_sign_out_path_for(resource_name)
@@ -76,7 +78,7 @@ class Devise::InvitationsController < DeviseController
   end
   
   def resource_from_invitation_token
-    unless params[:invitation_token] && self.resource = resource_class.find_by_invitation_token(params[:invitation_token], true)
+    unless params[:invitation_token] && @resource = resource_class.find_by_invitation_token(params[:invitation_token], true)
       set_flash_message(:alert, :invitation_token_invalid)
       redirect_to after_sign_out_path_for(resource_name)
     end


### PR DESCRIPTION
Using devise_invitable 1.3.4 I get a "cannot access invitation_token on nilObject" in invitations_controller.rb which came down to `resource` being lost from the relevant before_filter.  Changing the `resource` assignment there to use a direct reference (`@`) fixes this though adds two extra lines (setting back to self.resource in the controller methods to keep compatibility with views and other things).

Obviously this code works for other people so I'm not sure why it's so broken for me; this is something that to me looks like it never should have worked.  I'm confident I don't have anything else in a filter chain that could be overwriting or resetting self.resource.  Thoughts?
