### PR TITLE
update devise_invitable gem version number in readme

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -16,7 +16,7 @@ Install DeviseInvitable gem, it will also install dependencies (such as devise a
 Add DeviseInvitable to your Gemfile (and Devise if you weren't using them):
 
   gem 'devise',           '>= 2.0.0'
-  gem 'devise_invitable', '~> 1.1.0'
+  gem 'devise_invitable', '~> 1.3.4'
 
 === Automatic installation
 


### PR DESCRIPTION
Update the devise_invitable gem version to prevent railties gem version conflict when bundling on Rails 4.04 app.
