### PR TITLE
Removing deprecated assert_present and assert_blank methods on Rails 4.1

### DIFF
--- a/test/functional/registrations_controller_test.rb
+++ b/test/functional/registrations_controller_test.rb
@@ -25,7 +25,7 @@ class DeviseInvitable::RegistrationsControllerTest < ActionController::TestCase
     sign_out @issuer
 
     @invitee = User.where(:email => invitee_email).first
-    assert_blank @invitee.encrypted_password, "the password should be unset"
+    assert @invitee.encrypted_password.blank?, "the password should be unset"
 
     # sign_up the invitee
     assert_difference('ActionMailer::Base.deliveries.size') do
@@ -42,13 +42,13 @@ class DeviseInvitable::RegistrationsControllerTest < ActionController::TestCase
       @invitee.save!
     end
 
-    assert_present @invitee.encrypted_password
+    assert @invitee.encrypted_password.present?
     assert_not_nil @invitee.invitation_accepted_at
     assert_nil @invitee.invitation_token
-    assert_present @invitee.invited_by_id
-    assert_present @invitee.invited_by_type
+    assert @invitee.invited_by_id.present?
+    assert @invitee.invited_by_type.present?
     assert !@invitee.confirmed?
-    assert_present @invitee.confirmation_token
+    assert @invitee.confirmation_token.present?
   end
 
   test "not invitable resources can register" do
@@ -58,7 +58,7 @@ class DeviseInvitable::RegistrationsControllerTest < ActionController::TestCase
     post :create, :admin => {:email => invitee_email, :password => "1password"}
 
     @invitee = Admin.where(:email => invitee_email).first
-    assert_present @invitee.encrypted_password
+    assert @invitee.encrypted_password.present?
   end
 
   test "missing params on a create should not cause an error" do

--- a/test/integration/invitation_test.rb
+++ b/test/integration/invitation_test.rb
@@ -80,7 +80,7 @@ class InvitationTest < ActionDispatch::IntegrationTest
     end
     assert_equal user_invitation_path, current_path
     assert page.has_css?('#error_explanation li', :text => /Password .*doesn\'t match/)
-    assert_blank user.encrypted_password
+    assert user.encrypted_password.blank?
   end
 
   test 'not authenticated user with valid data should be able to change his password' do
@@ -99,7 +99,7 @@ class InvitationTest < ActionDispatch::IntegrationTest
     end
     assert_equal user_invitation_path, current_path
     assert page.has_css?('#error_explanation')
-    assert_blank user.encrypted_password
+    assert user.encrypted_password.blank?
 
     set_password :visit => false
     assert page.has_css?('p#notice', :text => 'Your password was set successfully. You are now signed in.')

--- a/test/models/invitable_test.rb
+++ b/test/models/invitable_test.rb
@@ -157,21 +157,21 @@ class InvitableTest < ActiveSupport::TestCase
 
   test 'should clear invitation token and set invitation_accepted_at while accepting the password' do
     user = User.invite!(:email => "valid@email.com")
-    assert_present user.invitation_token
+    assert user.invitation_token.present?
     assert_nil user.invitation_accepted_at
     user.accept_invitation!
     user.reload
     assert_nil user.invitation_token
-    assert_present user.invitation_accepted_at
+    assert user.invitation_accepted_at.present?
   end
 
   test 'should not clear invitation token or set accepted_at if record is invalid' do
     user = User.invite!(:email => "valid@email.com")
-    assert_present user.invitation_token
+    assert user.invitation_token.present?
     assert_nil user.invitation_accepted_at
     User.accept_invitation!(:invitation_token => user.invitation_token, :password => '123456789', :password_confirmation => '987654321')
     user.reload
-    assert_present user.invitation_token
+    assert user.invitation_token.present?
     assert_nil user.invitation_accepted_at
   end
 
@@ -182,8 +182,8 @@ class InvitableTest < ActiveSupport::TestCase
     user.reset_password_sent_at = Time.now.utc
     user.save
 
-    assert_present user.reset_password_token
-    assert_present user.invitation_token
+    assert user.reset_password_token.present?
+    assert user.invitation_token.present?
     User.reset_password_by_token(:reset_password_token => token, :password => '123456789', :password_confirmation => '123456789')
     assert_nil user.reload.reset_password_token
     assert_nil user.reload.invitation_token
@@ -197,11 +197,11 @@ class InvitableTest < ActiveSupport::TestCase
     user.reset_password_sent_at = Time.now.utc
     user.save
 
-    assert_present user.reset_password_token
-    assert_present user.invitation_token
+    assert user.reset_password_token.present?
+    assert user.invitation_token.present?
     User.reset_password_by_token(:reset_password_token => token, :password => '123456789', :password_confirmation => '12345678')
-    assert_present user.reload.reset_password_token
-    assert_present user.reload.invitation_token
+    assert user.reload.reset_password_token.present?
+    assert user.reload.invitation_token.present?
     assert user.invited_to_sign_up?
   end
 
@@ -212,7 +212,7 @@ class InvitableTest < ActiveSupport::TestCase
     user.reset_password_sent_at = Time.now.utc
     user.save
 
-    assert_present user.reset_password_token
+    assert user.reset_password_token.present?
     assert_nil user.invitation_token
     User.reset_password_by_token(:reset_password_token => token, :password => '123456789', :password_confirmation => '123456789')
     assert_nil user.reload.invitation_token
@@ -231,7 +231,7 @@ class InvitableTest < ActiveSupport::TestCase
   test 'should return a record with invitation token and no errors to send invitation by email' do
     invited_user = User.invite!(:email => "valid@email.com")
     assert invited_user.errors.blank?
-    assert_present invited_user.invitation_token
+    assert invited_user.invitation_token.present?
     assert_equal 'valid@email.com', invited_user.email
     assert invited_user.persisted?
   end
@@ -472,7 +472,7 @@ class InvitableTest < ActiveSupport::TestCase
     assert_no_difference('ActionMailer::Base.deliveries.size') do
       user.invite!
     end
-    assert_present user.invitation_created_at
+    assert user.invitation_created_at.present?
     assert_nil user.invitation_sent_at
   end
 


### PR DESCRIPTION
I'm working on making this gem tests work on Rails 4.1 and the first thing I noticed is that these methods have been deprecated, so I'm pushing this. I'll create other PRs to other fixes as I move forward.
