### PR TITLE
Replace deprecated ActionController::IntegrationTest with ActionDispatch::IntegrationTest

### DIFF
--- a/test/integration_tests_helper.rb
+++ b/test/integration_tests_helper.rb
@@ -1,9 +1,9 @@
-class ActionController::IntegrationTest
+class ActionDispatch::IntegrationTest
 
   def warden
     request.env['warden']
   end
-  
+
   def create_full_user
     @user ||= begin
       user = User.create!(


### PR DESCRIPTION
Rails 4.1 doesn't use ActionController::IntegrationTest at all.
