### PR TITLE
Change Devise::Mailer to Devise.mailer

### DIFF
--- a/lib/devise_invitable/rails.rb
+++ b/lib/devise_invitable/rails.rb
@@ -10,6 +10,9 @@ module DeviseInvitable
     # are included each time Devise.mailer is (re)loaded.
     config.to_prepare do
       Devise.mailer.send :include, DeviseInvitable::Mailer
+      unless Devise.mailer.ancestors.include?(Devise::Mailers::Helpers)
+        Devise.mailer.send :include, Devise::Mailers::Helpers 
+      end
     end
     # extend mapping with after_initialize because it's not reloaded
     config.after_initialize do


### PR DESCRIPTION
I have used devise_invitable with spree and spree_auth_devise and for make it work I did a monkey patch because spree_auth_devise don’t use Devise::Mailer, so I did this pull request to include DeviseInvitable::Mailer in the correct mailer defined from devise initializer, I also added a check to be sure that the mailer include Devise::Mailers::Helpers.
