### PR TITLE
Passing block to instance #invite! method

### DIFF
--- a/lib/devise_invitable/model.rb
+++ b/lib/devise_invitable/model.rb
@@ -114,6 +114,7 @@ module Devise
           def self.confirmation_required?; false; end
         end
 
+        yield self if block_given?
         generate_invitation_token if self.invitation_token.nil? || (!@skip_invitation && @raw_invitation_token.nil?)
         self.invitation_created_at = Time.now.utc
         self.invitation_sent_at = self.invitation_created_at unless @skip_invitation

--- a/test/models/invitable_test.rb
+++ b/test/models/invitable_test.rb
@@ -476,6 +476,17 @@ class InvitableTest < ActiveSupport::TestCase
     assert_nil user.invitation_sent_at
   end
 
+  test 'user.invite! should not send an invitation if we want to skip the invitation with block' do
+    user = new_user
+    assert_no_difference('ActionMailer::Base.deliveries.size') do
+      user.invite! do |u|
+        u.skip_invitation = true
+      end
+    end
+    assert user.invitation_created_at.present?
+    assert_nil user.invitation_sent_at
+  end
+
   test 'user.invite! should not set the invited_by attribute if not passed' do
     user = new_user
     user.invite!


### PR DESCRIPTION
Ability to pass a ruby block to `instance#invite!`
Ex: 

```
user = User.new
user.invite! { |u| u.skip_invitation = true }
```

Similar issue - #460
