### PR TITLE
Trust the user when establishes a counter cache column

### DIFF
--- a/lib/devise_invitable/model.rb
+++ b/lib/devise_invitable/model.rb
@@ -36,10 +36,6 @@ module Devise
         end
         if defined?(ActiveRecord) && self < ActiveRecord::Base
           counter_cache = Devise.invited_by_counter_cache
-          if !counter_cache && Devise.invited_by_class_name
-            klass = Devise.invited_by_class_name.constantize
-            counter_cache = klass.table_exists? && klass.columns_hash['invitations_count'].try('name')
-          end
           belongs_to_options.merge! :counter_cache => counter_cache if counter_cache
         end
         belongs_to :invited_by, belongs_to_options


### PR DESCRIPTION
We have problems running

``` sh
bundle exec rake db:create
```

That raise due to that code tries to get a connection to the database when even not exists yet.

Adding any extra code will add a lot complexity that IMHO is not needed. If the user provides a column to use as counter_cache column I think we should use that column directly.

In our case we have `Devise.invited_by_counter_cache` with the default value `nil` and still trying to ask for the counter_cache column in the table
