### PR TITLE
Use f.button :submit on simple_form templates to get the btn class.

### DIFF
--- a/lib/generators/devise_invitable/templates/simple_form_for/invitations/edit.html.erb
+++ b/lib/generators/devise_invitable/templates/simple_form_for/invitations/edit.html.erb
@@ -7,5 +7,5 @@
   <%= f.input :password %>
   <%= f.input :password_confirmation %>
 
-  <%= f.submit t("devise.invitations.edit.submit_button") %>
+  <%= f.button :submit, t("devise.invitations.edit.submit_button") %>
 <% end %>

--- a/lib/generators/devise_invitable/templates/simple_form_for/invitations/new.html.erb
+++ b/lib/generators/devise_invitable/templates/simple_form_for/invitations/new.html.erb
@@ -7,5 +7,5 @@
   <%= f.input field %>
 <% end -%>
 
-<%= f.submit t("devise.invitations.new.submit_button") %>
+<%= f.button :submit, t("devise.invitations.new.submit_button") %>
 <% end %>


### PR DESCRIPTION
Adds a 'btn' css class to the submit input if one is using Simple Form.

E.g. turns:

``` html
<input name="commit" type="submit" value="Set my password">
```

to this:

``` html
<input class="btn" name="commit" type="submit" value="Set my password">
```

It makes a nice bootstrap styled button. Devise also does this in it's simple form for generators.
