### PR TITLE
Update for Devise 3.3.0 using Log in not Sign in

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,7 +12,7 @@ GIT
 PATH
   remote: .
   specs:
-    devise_invitable (1.3.5)
+    devise_invitable (1.3.6)
       actionmailer (>= 3.2.6, < 5)
       devise (>= 3.2.0)
 
@@ -59,7 +59,7 @@ GEM
       xpath (~> 0.1.4)
     childprocess (0.3.9)
       ffi (~> 1.0, >= 1.0.11)
-    devise (3.2.4)
+    devise (3.3.0)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
       railties (>= 3.2.6, < 5)
@@ -88,7 +88,7 @@ GEM
     nokogiri (1.5.10)
     origin (1.1.0)
     orm_adapter (0.5.0)
-    polyglot (0.3.4)
+    polyglot (0.3.5)
     racc (1.4.10)
     rack (1.5.2)
     rack-test (0.6.2)

--- a/test/integration_tests_helper.rb
+++ b/test/integration_tests_helper.rb
@@ -24,7 +24,7 @@ class ActionDispatch::IntegrationTest
     visit send("new_#{resource_name}_session_path")
     fill_in "#{resource_name}_email", :with => user.email
     fill_in "#{resource_name}_password", :with => user.password
-    click_button 'Sign in'
+    click_button 'Log in'
   end
 
   # Fix assert_redirect_to in integration sessions because they don't take into


### PR DESCRIPTION
New devise has changed the name on the button, this will get your repository passing again :)
