### PR TITLE
Updated documentation to emphasize that @raw_invitation_token is ephemeral

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -257,7 +257,7 @@ You can add :skip_invitation to attributes hash if skip_invitation is added to a
 Skip_invitation skips sending the email, but sets invitation_token, so invited_to_sign_up? on the
 resulting user returns true.
 
-** Warning **
+**Warning**
 
 When using skip_invitation you must send the email with the user object instance that generated the tokens, as 
 user.raw_invitation_token is available only to the instance and is not persisted in the database.


### PR DESCRIPTION
I attempted to send a customized email in a resque job, I found out the when I rebuilt my user object, that .raw_invitation_token wasn't available.  This issue is likely to come up again with Rails 4.2 activejob.  

The steps to recreate the situation is:
1. Create user  user = User.new
2. user.skip_invitation = true
3. user.invite!(so_and_so)
4. user.save
5. Resque.enqueue(SendInvite, user.id.to_s)

the SendInvite will then send the invite and won't have access to @raw_invitation_token.

Thank you!

-daniel
