### PR TITLE
Check if ActiveRecord::Base is defined

### DIFF
--- a/lib/devise_invitable/model.rb
+++ b/lib/devise_invitable/model.rb
@@ -34,7 +34,7 @@ module Devise
         else
           {:polymorphic => true}
         end
-        if defined?(ActiveRecord) && self < ActiveRecord::Base
+        if defined?(ActiveRecord) && defined?(ActiveRecord::Base) && self < ActiveRecord::Base
           counter_cache = Devise.invited_by_counter_cache
           belongs_to_options.merge! :counter_cache => counter_cache if counter_cache
         end


### PR DESCRIPTION
I'm running into an issue using `devise_invitable` with https://github.com/AsteriskLabs/devise_google_authenticator. `devise_google_authenticator` creates a generator (https://github.com/AsteriskLabs/devise_google_authenticator/blob/master/lib/generators/active_record/devise_google_authenticator_generator.rb), checking for ActiveRecord but not ActiveRecord::Base, and this conflicts with https://github.com/jessicard/devise_invitable/blob/74ae8fa535c032326f68f393913425522881554e/lib/devise_invitable/model.rb#L37. This PR fixes that :)
