### PR TITLE
Moves yield around resource before checking if the invitation was successfully sent

### DIFF
--- a/app/controllers/devise/invitations_controller.rb
+++ b/app/controllers/devise/invitations_controller.rb
@@ -38,9 +38,11 @@ class Devise::InvitationsController < DeviseController
   # PUT /resource/invitation
   def update
     self.resource = accept_resource
+    invitation_accepted = resource.errors.empty?
 
-    if resource.errors.empty?
-      yield resource if block_given?
+    yield resource if block_given?
+
+    if invitation_accepted
       flash_message = resource.active_for_authentication? ? :updated : :updated_not_active
       set_flash_message :notice, flash_message if is_flashing_format?
       sign_in(resource_name, resource)


### PR DESCRIPTION
The previous behavior only let to add behavior if the invitation was successfully sent.

``` ruby
def create
  super do |resource|
    excecute_success_behavior
  end
end
```

With this fix, we can add a behavior when the invitation creation success or fails.

``` ruby
def create
  super do |resource|
    if resource.errors.empty?
      excecute_success_behavior
    else
      excecute_failure_behavior
    end
  end
end
```

Same goes when accepting the invitation.
