### PR TITLE
Allow configuration of automatic sign in functionality

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -132,6 +132,8 @@ or directly as parameters to the <tt>devise</tt> method:
 
 * invited_by_class_name: The class name of the inviting model. If this is nil, polymorphic association is used.
 
+* allow_insecure_sign_in_after_accept: automatically sign in the user after they set a password. Enabled by default.
+
 For more details, see <tt>config/initializers/devise.rb</tt> (after you invoked the "devise_invitable:install" generator described above).
 
 == Configuring views
@@ -355,6 +357,7 @@ DeviseInvitable uses flash messages with I18n with the flash keys <tt>:send_inst
         send_instructions: 'An invitation email has been sent to %{email}.'
         invitation_token_invalid: 'The invitation token provided is not valid!'
         updated: 'Your password was set successfully. You are now signed in.'
+        updated_not_active: 'Your password was set successfully.'
 
 You can also create distinct messages based on the resource you've configured using the singular name given in routes:
 
@@ -365,6 +368,7 @@ You can also create distinct messages based on the resource you've configured us
           send_instructions: 'A new user invitation has been sent to %{email}.'
           invitation_token_invalid: 'Your invitation token is not valid!'
           updated: 'Welcome on board! You are now signed in.'
+          updated_not_active: 'Welcome on board! Sign in to continue.'
 
 The DeviseInvitable mailer uses the same pattern as Devise to create mail subject messages:
 

--- a/app/controllers/devise/invitations_controller.rb
+++ b/app/controllers/devise/invitations_controller.rb
@@ -43,10 +43,15 @@ class Devise::InvitationsController < DeviseController
     yield resource if block_given?
 
     if invitation_accepted
-      flash_message = resource.active_for_authentication? ? :updated : :updated_not_active
-      set_flash_message :notice, flash_message if is_flashing_format?
-      sign_in(resource_name, resource)
-      respond_with resource, :location => after_accept_path_for(resource)
+      if Devise.allow_insecure_sign_in_after_accept
+        flash_message = resource.active_for_authentication? ? :updated : :updated_not_active
+        set_flash_message :notice, flash_message if is_flashing_format?
+        sign_in(resource_name, resource)
+        respond_with resource, :location => after_accept_path_for(resource)
+      else
+        set_flash_message :notice, :updated_not_active if is_flashing_format?
+        respond_with resource, :location => new_session_path(resource_name)
+      end
     else
       respond_with_navigational(resource){ render :edit }
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,6 +6,7 @@ en:
       send_instructions: "An invitation email has been sent to %{email}."
       invitation_token_invalid: "The invitation token provided is not valid!"
       updated: "Your password was set successfully. You are now signed in."
+      updated_not_active: "Your password was set successfully."
       no_invitations_remaining: "No invitations remaining"
       invitation_removed: "Your invitation was removed."
       new:

--- a/lib/devise_invitable.rb
+++ b/lib/devise_invitable.rb
@@ -66,6 +66,11 @@ module Devise
   # the #invited_by association is declared without counter_cache. (default: nil)
   mattr_accessor :invited_by_counter_cache
   @@invited_by_counter_cache = nil
+
+  # Public: Auto-login after the user accepts the invite. If this is false,
+  # the user will need to manually log in after accepting the invite (default: false).
+  mattr_accessor :allow_insecure_sign_in_after_accept
+  @@allow_insecure_sign_in_after_accept = true
 end
 
 Devise.add_module :invitable, :controller => :invitations, :model => 'devise_invitable/model', :route => {:invitation => [nil, :new, :accept]}

--- a/lib/devise_invitable/model.rb
+++ b/lib/devise_invitable/model.rb
@@ -303,6 +303,7 @@ module Devise
         Devise::Models.config(self, :invitation_limit)
         Devise::Models.config(self, :invite_key)
         Devise::Models.config(self, :resend_invitation)
+        Devise::Models.config(self, :allow_insecure_sign_in_after_accept)
       end
     end
   end

--- a/lib/generators/devise_invitable/install_generator.rb
+++ b/lib/generators/devise_invitable/install_generator.rb
@@ -57,6 +57,11 @@ module DeviseInvitable
   # Default: nil
   # config.invited_by_counter_cache = :invitations_count
 
+  # Auto-login after the user accepts the invite. If this is false,
+  # the user will need to manually log in after accepting the invite.
+  # Default: false
+  # config.allow_insecure_sign_in_after_accept = true
+
 CONTENT
             end
           end

--- a/test/integration/invitation_test.rb
+++ b/test/integration/invitation_test.rb
@@ -106,10 +106,26 @@ class InvitationTest < ActionDispatch::IntegrationTest
     assert user.reload.valid_password?('987654321')
   end
 
-  test 'sign in user automatically after setting it\'s password' do
+  test 'sign in user automatically after setting it\'s password if config.allow_insecure_sign_in_after_accept is true' do
+    original_option_value = Devise.allow_insecure_sign_in_after_accept
+    Devise.allow_insecure_sign_in_after_accept = true
+
     User.invite!(:email => "valid@email.com")
     set_password :invitation_token => Thread.current[:token]
+
     assert_equal root_path, current_path
+    Devise.allow_insecure_sign_in_after_accept = original_option_value
+  end
+
+  test 'does not sign in user automatically after setting it\'s password if config.allow_insecure_sign_in_after_accept is false' do
+    original_option_value = Devise.allow_insecure_sign_in_after_accept
+    Devise.allow_insecure_sign_in_after_accept = false
+
+    User.invite!(:email => "valid@email.com")
+    set_password :invitation_token => Thread.current[:token]
+
+    assert_equal new_user_session_path, current_path
+    Devise.allow_insecure_sign_in_after_accept = original_option_value
   end
 
   test 'clear token and set invitation_accepted_at after recover password instead of accept_invitation' do

--- a/test/rails_app/config/initializers/devise.rb
+++ b/test/rails_app/config/initializers/devise.rb
@@ -129,6 +129,11 @@ Devise.setup do |config|
   # Default: nil
   config.invited_by_counter_cache = :invitations_count
 
+  # Auto-login after the user accepts the invite. If this is false,
+  # the user will need to manually log in after accepting the invite.
+  # Default: true
+  # config.allow_insecure_sign_in_after_accept = false
+
   # ==> Configuration for :confirmable
   # A period that the user is allowed to access the website even without
   # confirming his account. For instance, if set to 2.days, the user will be


### PR DESCRIPTION
This is important if custom authentication strategies are needed. Auto signing in users can also be a security hole, especially if you have a custom authentication scope on your user model. Most of the other devise modules already include a similar configuration option.