### PR TITLE
add intermediate method in active_for_authentication? for more flexibility

### DIFF
--- a/lib/devise_invitable/model.rb
+++ b/lib/devise_invitable/model.rb
@@ -135,7 +135,7 @@ module Devise
 
       # Only verify password when is not invited
       def active_for_authentication?
-        super unless invited_to_sign_up?
+        super unless block_authentication_from_invitation?
       end
 
       def inactive_message
@@ -213,6 +213,10 @@ module Devise
 
         def generate_invitation_token!
           generate_invitation_token && save(:validate => false)
+        end
+
+        def block_authentication_from_invitation?
+          invited_to_sign_up?
         end
 
       module ClassMethods


### PR DESCRIPTION
Small change which provides more flexibility for customizing ```active_for_authentication?```. I needed to add additional condition and couldn't really do much as changing ```invited_to_sign_up?``` would break the behaviour in other methods and I ended up aliasing the "original" ```active_for_authentication?```. Having intermediate method for it solves the problem.