### PR TITLE
fix for undefined method `invite_key_fields' 

### DIFF
--- a/lib/devise_invitable/parameter_sanitizer.rb
+++ b/lib/devise_invitable/parameter_sanitizer.rb
@@ -20,7 +20,7 @@ module DeviseInvitable
     def attributes_for_with_invitable(kind)
       case kind
       when :invite
-        resource_class.invite_key_fields
+        resource_class.respond_to?(:invite_key_fields) ? resource_class.invite_key_fields : []
       when :accept_invitation
         [:password, :password_confirmation, :invitation_token]
       else attributes_for_without_invitable(kind)


### PR DESCRIPTION
if we have two models (like: User and Adminuser) that are devise enabled. and we have added invitable in one model (lets say User). and we need to add some more fields other then email while send invite. so need to permit those params for invite.
But while access the login view of other model, we have error for Sanitize params for invite

Please check my changes and if you feel I did right changes then please merge my changes.