### PR TITLE
Get list & check for user(s) created by invite irrespective of status

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -256,8 +256,10 @@ You can add :skip_invitation to attributes hash if skip_invitation is added to a
   User.invite!(:email => "new_user@example.com", :name => "John Doe", :skip_invitation => true)
   # => the record will be created, but the invitation email will not be sent
 
-Skip_invitation skips sending the email, but sets invitation_token, so invited_to_sign_up? on the
+Skip_invitation skips sending the email, but sets invitation_token, so <tt>invited_to_sign_up?</tt> on the
 resulting user returns true.
+
+To check if a perticular user is created by invitation, irrespective to state of invitation one can use <tt>created_by_invite?</tt>
 
 **Warning**
 
@@ -297,8 +299,9 @@ The callbacks support all options and arguments available to the standard callba
 
 A pair of scopes to find those users that have accepted, and those that have not accepted, invitations are defined:
 
-  User.invitation_accepted # => returns all Users for whom the invitation_accepted_at attribute is not nil
+  User.invitation_accepted     # => returns all Users for whom the invitation_accepted_at attribute is not nil
   User.invitation_not_accepted # => returns all Users for whom the invitation_accepted_at attribute is nil
+  User.created_by_invite       # => returns all Users who are created by invitations, irrespective to invitation status 
 
 == Integration in a Rails application
 

--- a/lib/devise_invitable/model.rb
+++ b/lib/devise_invitable/model.rb
@@ -47,9 +47,11 @@ module Devise
 
         scope :no_active_invitation, lambda { where(:invitation_token => nil) }
         if defined?(Mongoid) && defined?(Mongoid::Document) && self < Mongoid::Document
+          scope :created_by_invite, lambda { where(:invitation_sent_at.ne => nil) }
           scope :invitation_not_accepted, lambda { where(:invitation_accepted_at => nil, :invitation_token.ne => nil) }
           scope :invitation_accepted, lambda { where(:invitation_accepted_at.ne => nil) }
         else
+          scope :created_by_invite, lambda { where(arel_table[:invitation_sent_at].not_eq(nil)) }
           scope :invitation_not_accepted, lambda { where(arel_table[:invitation_token].not_eq(nil)).where(:invitation_accepted_at => nil) }
           scope :invitation_accepted, lambda { where(arel_table[:invitation_accepted_at].not_eq(nil)) }
 
@@ -83,6 +85,11 @@ module Devise
             self.save(:validate => false)
           end
         end
+      end
+
+      # Verify wheather a user is created by invitation, irrespective to invitation status
+      def created_by_invite?
+        invitation_sent_at.present?
       end
 
       # Verifies whether a user has been invited or not


### PR DESCRIPTION
Added a scope to get list of users created by invitation (irrespective of status of invitation) & a object method for same. Added tests for both.