### PR TITLE
Update template's hash syntax

### DIFF
--- a/lib/generators/active_record/templates/migration.rb
+++ b/lib/generators/active_record/templates/migration.rb
@@ -6,10 +6,10 @@ class DeviseInvitableAddTo<%= table_name.camelize %> < ActiveRecord::Migration
       t.datetime   :invitation_sent_at
       t.datetime   :invitation_accepted_at
       t.integer    :invitation_limit
-      t.references :invited_by, :polymorphic => true
+      t.references :invited_by, polymorphic: true
       t.integer    :invitations_count, default: 0
       t.index      :invitations_count
-      t.index      :invitation_token, :unique => true # for invitable
+      t.index      :invitation_token, unique: true # for invitable
       t.index      :invited_by_id
     end
 
@@ -22,7 +22,7 @@ class DeviseInvitableAddTo<%= table_name.camelize %> < ActiveRecord::Migration
 
   def down
     change_table :<%= table_name %> do |t|
-      t.remove_references :invited_by, :polymorphic => true
+      t.remove_references :invited_by, polymorphic: true
       t.remove :invitations_count, :invitation_limit, :invitation_sent_at, :invitation_accepted_at, :invitation_token, :invitation_created_at
     end
     change_column_null    :<%= table_name %>, :encrypted_password, false

--- a/lib/generators/devise_invitable/templates/simple_form_for/invitations/edit.html.erb
+++ b/lib/generators/devise_invitable/templates/simple_form_for/invitations/edit.html.erb
@@ -1,6 +1,6 @@
 <h2><%= t 'devise.invitations.edit.header' %></h2>
 
-<%= simple_form_for resource, :as => resource_name, :url => invitation_path(resource_name), :html => { :method => :put } do |f| %>
+<%= simple_form_for resource, as: resource_name, url: invitation_path(resource_name), html: { method: :put } do |f| %>
   <%= devise_error_messages! %>
   <%= f.hidden_field :invitation_token %>
 

--- a/lib/generators/devise_invitable/templates/simple_form_for/invitations/new.html.erb
+++ b/lib/generators/devise_invitable/templates/simple_form_for/invitations/new.html.erb
@@ -1,6 +1,6 @@
 <h2><%= t "devise.invitations.new.header" %></h2>
 
-<%= simple_form_for resource, :as => resource_name, :url => invitation_path(resource_name), :html => {:method => :post} do |f| %>
+<%= simple_form_for resource, as: resource_name, url: invitation_path(resource_name), html: { method: :post} do |f| %>
   <%= devise_error_messages! %>
 
 <% resource.class.invite_key_fields.each do |field| -%>


### PR DESCRIPTION
I updated template files' hash syntax, so that users won't need to change them manually after generated them.