### PR TITLE
Check if after_password_reset is defined

### DIFF
--- a/lib/devise_invitable/model.rb
+++ b/lib/devise_invitable/model.rb
@@ -151,7 +151,7 @@ module Devise
       end
 
       def after_password_reset
-        super
+        super if defined?(super)
         accept_invitation! if invited_to_sign_up?
       end
 


### PR DESCRIPTION
Check if after_password_reset is defined, because devise (3.5.1) removed `after_password_reset` on [this commit](https://github.com/plataformatec/devise/commit/31901bc862db60878130fcd9cbf9c4895d41b2d2).

ref: #554 

We still got a warning like `DEPRECATION WARNING: after_password_reset is deprecated.`, so I think we will stop using `after_password_reset` in the near future.
