### PR TITLE
Add support for setting invited_by foreign key

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -132,6 +132,8 @@ or directly as parameters to the <tt>devise</tt> method:
 
 * invited_by_class_name: The class name of the inviting model. If this is nil, polymorphic association is used.
 
+* invited_by_foreign_key: The foreign key to the inviting model (only used if invited_by_class_name is set, otherwise :invited_by_id)
+
 * allow_insecure_sign_in_after_accept: automatically sign in the user after they set a password. Enabled by default.
 
 For more details, see <tt>config/initializers/devise.rb</tt> (after you invoked the "devise_invitable:install" generator described above).

--- a/lib/devise_invitable.rb
+++ b/lib/devise_invitable.rb
@@ -62,6 +62,11 @@ module Devise
   mattr_accessor :invited_by_class_name
   @@invited_by_class_name = nil
 
+  # Public: The foreign key to the inviting model (if invited_by_class_name is set)
+  # (default: :invited_by_id)
+  mattr_accessor :invited_by_foreign_key
+  @@invited_by_foreign_key = nil
+
   # Public: The column name used for counter_cache column. If this is nil,
   # the #invited_by association is declared without counter_cache. (default: nil)
   mattr_accessor :invited_by_counter_cache

--- a/lib/devise_invitable/model.rb
+++ b/lib/devise_invitable/model.rb
@@ -34,6 +34,9 @@ module Devise
         else
           {:polymorphic => true}
         end
+	if fk = Devise.invited_by_foreign_key
+	  belongs_to_options[:foreign_key] = fk
+	end
         if defined?(ActiveRecord) && defined?(ActiveRecord::Base) && self < ActiveRecord::Base
           counter_cache = Devise.invited_by_counter_cache
           belongs_to_options.merge! :counter_cache => counter_cache if counter_cache
@@ -63,7 +66,7 @@ module Devise
 
       def self.required_fields(klass)
         fields = [:invitation_token, :invitation_created_at, :invitation_sent_at, :invitation_accepted_at,
-         :invitation_limit, :invited_by_id, :invited_by_type]
+         :invitation_limit, Devise.invited_by_foreign_key || :invited_by_id, :invited_by_type]
         fields << :invitations_count if defined?(ActiveRecord) && self < ActiveRecord::Base
         fields -= [:invited_by_type] if Devise.invited_by_class_name
         fields

--- a/lib/generators/devise_invitable/install_generator.rb
+++ b/lib/generators/devise_invitable/install_generator.rb
@@ -52,6 +52,10 @@ module DeviseInvitable
   # Default: nil
   # config.invited_by_class_name = 'User'
 
+  # The foreign key to the inviting model (if invited_by_class_name is set)
+  # Default: :invited_by_id
+  # config.invited_by_foreign_key = :invited_by_id
+
   # The column name used for counter_cache column. If this is nil,
   # the #invited_by association is declared without counter_cache.
   # Default: nil

--- a/test/rails_app/config/initializers/devise.rb
+++ b/test/rails_app/config/initializers/devise.rb
@@ -124,6 +124,10 @@ Devise.setup do |config|
   # Default: nil
   # config.invited_by_class_name = 'User'
 
+  # The foreign key to the inviting model (if invited_by_class_name is set)
+  # Default: :invited_by_id
+  # config.invited_by_foreign_key = :invited_by_id
+
   # The column name used for counter_cache column. If this is nil,
   # the #invited_by association is declared without counter_cache.
   # Default: nil


### PR DESCRIPTION
I'm using GUIDs for keys, and my modeling tools generate invited_by_guid instead of invited_by_id as the foreign key. This little enhancement allows me to configure that on the belongs_to association.