### PR TITLE
Set random initial password for invited users

### DIFF
--- a/app/controllers/devise_invitable/registrations_controller.rb
+++ b/app/controllers/devise_invitable/registrations_controller.rb
@@ -4,8 +4,8 @@ class DeviseInvitable::RegistrationsController < Devise::RegistrationsController
   def build_resource(hash = nil)
     hash ||= resource_params || {}
     if hash[:email]
-      self.resource = resource_class.where(:email => hash[:email], :encrypted_password => '').first
-      if self.resource
+      self.resource = resource_class.where(:email => hash[:email]).first
+      if self.resource and self.resource.invited_to_sign_up?
         self.resource.attributes = hash
         self.resource.send_confirmation_instructions if self.resource.confirmation_required_for_invited?
         self.resource.accept_invitation

--- a/test/functional/registrations_controller_test.rb
+++ b/test/functional/registrations_controller_test.rb
@@ -25,7 +25,6 @@ class DeviseInvitable::RegistrationsControllerTest < ActionController::TestCase
     sign_out @issuer
 
     @invitee = User.where(:email => invitee_email).first
-    assert @invitee.encrypted_password.blank?, "the password should be unset"
     assert_nil @invitee.invitation_accepted_at
     assert_not_nil @invitee.invitation_token
     assert !@invitee.confirmed?

--- a/test/integration/invitation_test.rb
+++ b/test/integration/invitation_test.rb
@@ -99,7 +99,7 @@ class InvitationTest < ActionDispatch::IntegrationTest
     end
     assert_equal user_invitation_path, current_path
     assert page.has_css?('#error_explanation li', :text => /Password .*doesn\'t match/)
-    assert user.encrypted_password.blank?
+    assert !user.confirmed?
   end
 
   test 'not authenticated user with valid data should be able to change his password' do
@@ -109,6 +109,7 @@ class InvitationTest < ActionDispatch::IntegrationTest
     assert_equal root_path, current_path
     assert page.has_css?('p#notice', :text => 'Your password was set successfully. You are now signed in.')
     assert user.reload.valid_password?('987654321')
+    assert user.confirmed?
   end
 
   test 'after entering invalid data user should still be able to set his password' do
@@ -118,7 +119,6 @@ class InvitationTest < ActionDispatch::IntegrationTest
     end
     assert_equal user_invitation_path, current_path
     assert page.has_css?('#error_explanation')
-    assert user.encrypted_password.blank?
 
     set_password :visit => false
     assert page.has_css?('p#notice', :text => 'Your password was set successfully. You are now signed in.')


### PR DESCRIPTION
Closes #531 

This doesn't touch the migration that allows null encrypted_password and password_salt, that's still up for discussion.