### PR TITLE
Don't override password

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@
 - Fix #571, accept invitation when password changes only if reset_password_token was present
 - Add support for setting invited_by foreign key
 - Set random initial password for invited users
+- Don't override password while User.invite!
 
 = 1.5.1
 

--- a/lib/devise_invitable/model.rb
+++ b/lib/devise_invitable/model.rb
@@ -254,7 +254,9 @@ module Devise
           invitable = find_or_initialize_with_errors(invite_key_array, attributes_hash)
           invitable.assign_attributes(attributes)
           invitable.invited_by = invited_by
-          invitable.password = Devise.friendly_token[0, 20]
+          unless invitable.password
+            invitable.password = Devise.friendly_token[0, 20]
+          end
 
           invitable.valid? if self.validate_on_invite
           if invitable.new_record?

--- a/test/models/invitable_test.rb
+++ b/test/models/invitable_test.rb
@@ -181,6 +181,11 @@ class InvitableTest < ActiveSupport::TestCase
     assert_not_equal old_encrypted_password, user.encrypted_password
   end
 
+  test 'should not override password on invite!' do
+    user = User.invite!(:email => "valid@email.com", :password => 'password', :password_confirmation => 'password', :skip_invitation => true)
+    assert user.valid?
+  end
+
   test 'should clear invitation token and set invitation_accepted_at while accepting the password' do
     user = User.invite!(:email => "valid@email.com")
     assert user.invitation_token.present?


### PR DESCRIPTION
Don't override password if it alreadt set.

This code:
```
User.invite!(email: 'igor.zubkov@gmail.com', password: 'password', password_confirmation: 'password', skip_invitation: true)
```

will fail with:
```
ActiveRecord::RecordInvalid: Validation failed: Password confirmation doesn't match Password
```
