### PR TITLE
Define translation_scope

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+= Unreleased
+
+- Controllers inheriting from Devise::InvitationsController will now use 'devise.invitations' translations
+  when using Devise >= 3.5. See https://github.com/plataformatec/devise/pull/3407 for more details.
+
 = 1.5.2
 
 - Fix #571, accept invitation when password changes only if reset_password_token was present

--- a/app/controllers/devise/invitations_controller.rb
+++ b/app/controllers/devise/invitations_controller.rb
@@ -103,5 +103,8 @@ class Devise::InvitationsController < DeviseController
     devise_parameter_sanitizer.sanitize(:accept_invitation)
   end
 
+  def translation_scope
+    'devise.invitations'
+  end
 end
 


### PR DESCRIPTION
In the latest version of Devise, they have made inheriting from a Devise controller keep the same I18n keys. https://github.com/plataformatec/devise/pull/3407

I'm not sure if this is a breaking change, it wasn't for Devise (it would have broken our app though)