### PR TITLE
Add options to invite!

### DIFF
--- a/lib/devise_invitable/model.rb
+++ b/lib/devise_invitable/model.rb
@@ -275,7 +275,7 @@ module Devise
           end
 
           yield invitable if block_given?
-          mail = invitable.invite!(invited_by, options) if invitable.errors.empty?
+          mail = invitable.invite!(nil, options) if invitable.errors.empty?
           [invitable, mail]
         end
 

--- a/lib/devise_invitable/model.rb
+++ b/lib/devise_invitable/model.rb
@@ -283,8 +283,8 @@ module Devise
           _invite(attributes.with_indifferent_access, invited_by, options, &block).first
         end
 
-        def invite_mail!(attributes={}, invited_by=nil, &block)
-          _invite(attributes, invited_by, &block).last
+        def invite_mail!(attributes={}, invited_by=nil, options = {}, &block)
+          _invite(attributes, invited_by, options, &block).last
         end
 
         # Attempt to find a user by it's invitation_token to set it's password.

--- a/lib/devise_invitable/model.rb
+++ b/lib/devise_invitable/model.rb
@@ -109,8 +109,8 @@ module Devise
       end
 
       # Reset invitation token and send invitation again
-      def invite!(invited_by = nil)
-        # This is an order-dependant assignment, this can't be moved 
+      def invite!(invited_by = nil, options = {})
+        # This is an order-dependant assignment, this can't be moved
         was_invited = invited_to_sign_up?
 
         # Required to workaround confirmable model's confirmation_required? method
@@ -131,7 +131,7 @@ module Devise
 
         if save(:validate => false)
           self.invited_by.decrement_invitation_limit! if !was_invited and self.invited_by.present?
-          deliver_invitation unless skip_invitation
+          deliver_invitation(options) unless skip_invitation
         end
       end
 
@@ -164,10 +164,10 @@ module Devise
       end
 
       # Deliver the invitation email
-      def deliver_invitation
+      def deliver_invitation(options = {})
         generate_invitation_token! unless @raw_invitation_token
         self.update_attribute :invitation_sent_at, Time.now.utc unless self.invitation_sent_at
-        send_devise_notification(:invitation_instructions, @raw_invitation_token)
+        send_devise_notification(:invitation_instructions, @raw_invitation_token, options)
       end
 
       # provide alias to the encrypted invitation_token stored by devise
@@ -249,7 +249,7 @@ module Devise
         # email is resent unless resend_invitation is set to false.
         # Attributes must contain the user's email, other attributes will be
         # set in the record
-        def _invite(attributes={}, invited_by=nil, &block)
+        def _invite(attributes={}, invited_by=nil, options = {}, &block)
           invite_key_array = invite_key_fields
           attributes_hash = {}
           invite_key_array.each do |k,v|
@@ -275,12 +275,12 @@ module Devise
           end
 
           yield invitable if block_given?
-          mail = invitable.invite! if invitable.errors.empty?
+          mail = invitable.invite!(invited_by, options) if invitable.errors.empty?
           [invitable, mail]
         end
 
-        def invite!(attributes={}, invited_by=nil, &block)
-          _invite(attributes.with_indifferent_access, invited_by, &block).first
+        def invite!(attributes={}, invited_by=nil, options = {}, &block)
+          _invite(attributes.with_indifferent_access, invited_by, options, &block).first
         end
 
         def invite_mail!(attributes={}, invited_by=nil, &block)
@@ -342,4 +342,3 @@ module Devise
     end
   end
 end
-

--- a/test/mailers/invitation_mail_test.rb
+++ b/test/mailers/invitation_mail_test.rb
@@ -75,4 +75,21 @@ class InvitationMailTest < ActionMailer::TestCase
     due_date_regexp = %r{#{I18n.l user.invitation_due_at, format: :'devise.mailer.invitation_instructions.accept_until_format' }}
     assert_match due_date_regexp, body
   end
+
+  test 'options are passed to the delivery method' do
+    class CustomMailer < Devise::Mailer
+      class << self
+        def invitation_instructions(record, name, options = {})
+          fail 'Options not as expected' unless options[:invited_at].is_a?(Time)
+          new(record, name, options)
+        end
+      end
+
+      def initialize(*args); end
+      def deliver; end
+    end
+    Devise.mailer = CustomMailer
+
+    User.invite!({ email: 'valid@email.com' }, nil, { invited_at: Time.now })
+  end
 end

--- a/test/model_tests_helper.rb
+++ b/test/model_tests_helper.rb
@@ -1,5 +1,6 @@
 class ActiveSupport::TestCase
   def setup_mailer
+    Devise.mailer = Devise::Mailer
     ActionMailer::Base.deliveries = []
   end
 


### PR DESCRIPTION
In certain scenarios it can be quite handy to be able to pass additional options to the invitation call. 

Our specific use case is to pass a not yet persisted object to the templating step and to use parts of it when generating the body of the invitation email.