### PR TITLE
add invite_created callbacks

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -265,7 +265,7 @@ To check if a particular user is created by invitation, irrespective to state of
 
 **Warning**
 
-When using skip_invitation you must send the email with the user object instance that generated the tokens, as 
+When using skip_invitation you must send the email with the user object instance that generated the tokens, as
 user.raw_invitation_token is available only to the instance and is not persisted in the database.
 
 You can send an invitation to an existing user if your workflow creates them separately:
@@ -287,12 +287,17 @@ To accept an invitation with a token use the <tt>accept_invitation!</tt> class m
 
 === Callbacks
 
-A callback event is fired before and after an invitation is accepted (User#accept_invitation!). For example, in your resource model you can add:
+A callback event is fired before and after an invitation is created (User#invite!) or accepted (User#accept_invitation!). For example, in your resource model you can add:
 
+  before_invitation_created :email_admins
   after_invitation_accepted :email_invited_by
 
+  def email_admins
+    # ...
+  end
+
   def email_invited_by
-     # ...
+    # ...
   end
 
 The callbacks support all options and arguments available to the standard callbacks provided by AR.
@@ -303,7 +308,7 @@ A pair of scopes to find those users that have accepted, and those that have not
 
   User.invitation_accepted     # => returns all Users for whom the invitation_accepted_at attribute is not nil
   User.invitation_not_accepted # => returns all Users for whom the invitation_accepted_at attribute is nil
-  User.created_by_invite       # => returns all Users who are created by invitations, irrespective to invitation status 
+  User.created_by_invite       # => returns all Users who are created by invitations, irrespective to invitation status
 
 == Integration in a Rails application
 

--- a/test/rails_app/app/models/user.rb
+++ b/test/rails_app/app/models/user.rb
@@ -36,9 +36,9 @@ class User < PARENT_MODEL_CLASS
 
   devise :database_authenticatable, :registerable, :validatable, :confirmable, :invitable, :recoverable
 
-  attr_accessor :callback_works, :bio, :token
+  attr_accessor :after_invitation_created_callback_works, :after_invitation_accepted_callback_works, :bio, :token
   validates :username, :length => { :maximum => 20 }
-  
+
   attr_accessor :testing_accepted_or_not_invited
   validates :username, :presence => true, :if => :testing_accepted_or_not_invited_validator?
   validates :bio, :presence => true, :if => :invitation_accepted?
@@ -47,8 +47,12 @@ class User < PARENT_MODEL_CLASS
     testing_accepted_or_not_invited && accepted_or_not_invited?
   end
 
+  after_invitation_created do |object|
+    object.after_invitation_created_callback_works = true
+  end
+
   after_invitation_accepted do |object|
-    object.callback_works = true
+    object.after_invitation_accepted_callback_works = true
   end
 
   def send_devise_notification(method, raw, *args)


### PR DESCRIPTION
@scambra what do you think of this?

I made it so that the `before_invite_created` callbacks run before the line that sets `invitation_created_at`. That way, if there is an expensive operation happening in the calback, it won't make the creation time artificially early. Not sure if that is the right place, but it seemed right to me!

Apologies for the `README.rdoc` trailing whitespace changes - my editor does it automatically. I can take them out if you'd like!

Resolves #617 