### PR TITLE
belongs_to requires presence by default in Rails 5

### DIFF
--- a/lib/devise_invitable/model.rb
+++ b/lib/devise_invitable/model.rb
@@ -40,6 +40,7 @@ module Devise
         if defined?(ActiveRecord) && defined?(ActiveRecord::Base) && self < ActiveRecord::Base
           counter_cache = Devise.invited_by_counter_cache
           belongs_to_options.merge! :counter_cache => counter_cache if counter_cache
+          belongs_to_options.merge! :optional => true if ActiveRecord::VERSION::MAJOR >= 5
         end
         belongs_to :invited_by, belongs_to_options
 


### PR DESCRIPTION
Rails 5 automatically adds a presence validation on belongs_to associations:

* https://github.com/rails/rails/issues/18233
* http://edgeapi.rubyonrails.org/classes/ActiveRecord/Associations/ClassMethods.html#method-i-belongs_to

This change prevents from creating users outside the invitation workflow.