### PR TITLE
Remove alias method chain

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,10 @@ language: ruby
 sudo: false
 cache: bundler
 rvm:
-  - 1.9.3
   - 2.0.0
   - 2.2.2
   - rbx-2
-  - jruby-19mode
+  - jruby-9.0.5.0
 script: bundle exec rake test
 env:
   - DEVISE_ORM=active_record
@@ -25,10 +24,10 @@ matrix:
       env: DEVISE_ORM=active_record
   allow_failures:
     - gemfile: gemfiles/Gemfile.devise-master
-  exclude:
-    - rvm: jruby-19mode
-      gemfile: gemfiles/Gemfile.rails-3.2.x
-      env: DEVISE_ORM=active_record
-    - rvm: jruby-19mode
-      gemfile: gemfiles/Gemfile.rails-3.2.x
-      env: DEVISE_ORM=mongoid
+#  exclude:
+#    - rvm: jruby-19mode
+#      gemfile: gemfiles/Gemfile.rails-3.2.x
+#      env: DEVISE_ORM=active_record
+#    - rvm: jruby-19mode
+#      gemfile: gemfiles/Gemfile.rails-3.2.x
+#      env: DEVISE_ORM=mongoid

--- a/lib/devise_invitable/mapping.rb
+++ b/lib/devise_invitable/mapping.rb
@@ -1,14 +1,10 @@
 module DeviseInvitable
   module Mapping
-    def self.included(base)
-      base.alias_method_chain :default_controllers, :invitable
-    end
-    
     private
-    def default_controllers_with_invitable(options)
+    def default_controllers(options)
       options[:controllers] ||= {}
       options[:controllers][:registrations] ||= "devise_invitable/registrations"
-      default_controllers_without_invitable(options)
+      super
     end
   end
 end

--- a/lib/devise_invitable/parameter_sanitizer.rb
+++ b/lib/devise_invitable/parameter_sanitizer.rb
@@ -10,14 +10,6 @@ module DeviseInvitable
       end
     end
 
-    def self.included(base)
-      if defined?(Devise::BaseSanitizer)
-        base.alias_method_chain :attributes_for, :invitable
-      else
-        base.alias_method_chain :initialize, :invitable
-      end
-    end
-
     private
 
     if defined?(Devise::BaseSanitizer)
@@ -25,18 +17,19 @@ module DeviseInvitable
         default_params.permit(*Array(keys))
       end
 
-      def attributes_for_with_invitable(kind)
+      def attributes_for(kind)
         case kind
         when :invite
           resource_class.respond_to?(:invite_key_fields) ? resource_class.invite_key_fields : []
         when :accept_invitation
           [:password, :password_confirmation, :invitation_token]
-        else attributes_for_without_invitable(kind)
+        else
+          super
         end
       end
     else
-      def initialize_with_invitable(resource_class, resource_name, params)
-        initialize_without_invitable(resource_class, resource_name, params)
+      def initialize(resource_class, resource_name, params)
+        super
         permit(:invite, keys: (resource_class.respond_to?(:invite_key_fields) ? resource_class.invite_key_fields : []) )
         permit(:accept_invitation, keys: [:password, :password_confirmation, :invitation_token] )
       end

--- a/lib/devise_invitable/rails.rb
+++ b/lib/devise_invitable/rails.rb
@@ -16,8 +16,8 @@ module DeviseInvitable
     end
     # extend mapping with after_initialize because it's not reloaded
     config.after_initialize do
-      Devise::Mapping.send :include, DeviseInvitable::Mapping
-      Devise::ParameterSanitizer.send :include, DeviseInvitable::ParameterSanitizer
+      Devise::Mapping.send :prepend, DeviseInvitable::Mapping
+      Devise::ParameterSanitizer.send :prepend, DeviseInvitable::ParameterSanitizer
     end
   end
 end


### PR DESCRIPTION
This obviously requires to drop Ruby 1.9 support, but the code is cleaner plus it clears a few Rails 5 deprecation warnings.