### PR TITLE
Update install generator to match readme

### DIFF
--- a/lib/generators/devise_invitable/install_generator.rb
+++ b/lib/generators/devise_invitable/install_generator.rb
@@ -63,8 +63,8 @@ module DeviseInvitable
 
   # Auto-login after the user accepts the invite. If this is false,
   # the user will need to manually log in after accepting the invite.
-  # Default: false
-  # config.allow_insecure_sign_in_after_accept = true
+  # Default: true
+  # config.allow_insecure_sign_in_after_accept = false
 
 CONTENT
             end


### PR DESCRIPTION
The README is correctly stating that default value for `config.allow_insecure_sign_in_after_accept` is true, but in install generator the default was said to be false.