### PR TITLE
Bug fix: Rails 4.2 changes to find_by

### DIFF
--- a/app/controllers/devise/invitations_controller.rb
+++ b/app/controllers/devise/invitations_controller.rb
@@ -99,7 +99,7 @@ class Devise::InvitationsController < DeviseController
   end
 
   def resource_from_invitation_token
-    unless params[:invitation_token] && self.resource = resource_class.find_by_invitation_token(params[:invitation_token], true)
+    unless params[:invitation_token] && self.resource = resource_class.find_by(invitation_token: params[:invitation_token])
       set_flash_message(:alert, :invitation_token_invalid) if is_flashing_format?
       redirect_to after_sign_out_path_for(resource_name)
     end


### PR DESCRIPTION
http://edgeguides.rubyonrails.org/4_2_release_notes.html

Whilst upgrading rails in one of our projects I had to override
resource_from_invitation_token method to use stricter find_by
ActiveRecord syntax. Otherwise it was returning nil when looking
up invitable record. Seems to work fine for us. What do you reckon?