### PR TITLE
Adding invited resource to after_invite_path_for

### DIFF
--- a/app/controllers/devise/invitations_controller.rb
+++ b/app/controllers/devise/invitations_controller.rb
@@ -32,7 +32,11 @@ class Devise::InvitationsController < DeviseController
       if is_flashing_format? && self.resource.invitation_sent_at
         set_flash_message :notice, :send_instructions, :email => self.resource.email
       end
-      respond_with resource, :location => after_invite_path_for(current_inviter)
+      if self.method(:after_invite_path_for).arity == 2
+        respond_with resource, :location => after_invite_path_for(current_inviter, resource)
+      else
+        respond_with resource, :location => after_invite_path_for(current_inviter)
+      end
     else
       respond_with_navigational(resource) { render :new }
     end
@@ -117,4 +121,3 @@ class Devise::InvitationsController < DeviseController
     'devise.invitations'
   end
 end
-

--- a/test/functional/controller_helpers_test.rb
+++ b/test/functional/controller_helpers_test.rb
@@ -6,32 +6,37 @@ class ControllerHelpersTest < ActionController::TestCase
   test "after invite path defaults to after sign in path" do
     assert_equal @controller.send(:after_sign_in_path_for, :user), @controller.after_invite_path_for(:user)
   end
-  
+
   test "after accept path defaults to after sign in path" do
     assert_equal @controller.send(:after_sign_in_path_for, :user), @controller.after_accept_path_for(:user)
   end
-  
+
   test 'after invite path is customizable from application controller' do
     custom_path = 'customized/after/invite/path'
     @controller.instance_eval "def after_invite_path_for(resource) '#{custom_path}' end"
     assert_equal @controller.after_invite_path_for(:user), custom_path
   end
-  
+
+  test 'after invite path is customizable from application controller with invited' do
+    custom_path = 'customized/after/invite/path'
+    @controller.instance_eval "def after_invite_path_for(resource, invited) '#{custom_path}' end"
+    assert_equal @controller.after_invite_path_for(:user, :invited), custom_path
+  end
   test 'after accept path is customizable from application controller' do
     custom_path = 'customized/after/accept/path'
     @controller.instance_eval "def after_accept_path_for(resource) '#{custom_path}' end"
     assert_equal @controller.after_accept_path_for(:user), custom_path
   end
-  
+
   test 'is not a devise controller' do
     assert !@controller.devise_controller?
   end
-  
+
   test 'invitations controller respects definition for after invite path in application controller' do
     assert Devise::InvitationsController.method_defined? :after_invite_path_for
     assert !Devise::InvitationsController.instance_methods(false).include?(:after_invite_path_for)
   end
-  
+
   test 'invitations controller respects definition for after accept path in application controller' do
     assert Devise::InvitationsController.method_defined? :after_accept_path_for
     assert !Devise::InvitationsController.instance_methods(false).include?(:after_accept_path_for)


### PR DESCRIPTION
Im my use case there are different types of user being invited and the redirect post invite should go to different places.  The original code only supplied the 'inviter'.  I've added the option to have a second parameter that includes the 'invitee'.  Backward compatibility is handled by checking the arity of the defined method to determine how many parameters to pass in.  I've also added a test, fairly limited but should cover the change.