### PR TITLE
Make belongs_to relationship presence optional

### DIFF
--- a/lib/devise_invitable/model.rb
+++ b/lib/devise_invitable/model.rb
@@ -34,6 +34,7 @@ module Devise
         else
           {:polymorphic => true}
         end
+        belongs_to_options[:optional] = true
         if fk = Devise.invited_by_foreign_key
           belongs_to_options[:foreign_key] = fk
         end


### PR DESCRIPTION
Mongoid 6 makes belongs to relationships mandatory by default.
This pull request sets `optional: true` for `belongs_to` relationship of `invited_by`.
This lets new user sign up with devise, without mongo having to complain about the `nil` value for `invited_by`.