### PR TITLE
Yield `resource` before validity/acceptance checks

### DIFF
--- a/app/controllers/devise/invitations_controller.rb
+++ b/app/controllers/devise/invitations_controller.rb
@@ -24,11 +24,10 @@ class Devise::InvitationsController < DeviseController
   # POST /resource/invitation
   def create
     self.resource = invite_resource
-    resource_invited = resource.errors.empty?
 
     yield resource if block_given?
 
-    if resource_invited
+    if resource.errors.empty?
       if is_flashing_format? && self.resource.invitation_sent_at
         set_flash_message :notice, :send_instructions, :email => self.resource.email
       end
@@ -53,11 +52,10 @@ class Devise::InvitationsController < DeviseController
   def update
     raw_invitation_token = update_resource_params[:invitation_token]
     self.resource = accept_resource
-    invitation_accepted = resource.errors.empty?
 
     yield resource if block_given?
 
-    if invitation_accepted
+    if resource.errors.empty?
       if Devise.allow_insecure_sign_in_after_accept
         flash_message = resource.active_for_authentication? ? :updated : :updated_not_active
         set_flash_message :notice, flash_message if is_flashing_format?


### PR DESCRIPTION
In certain circumstances, I need to allow the user to do more than simply set a password when accepting an invite. A simple example is to allow the user to set their name etc. If this is required by the model validations, it currently breaks.

By checking if for validation errors (`invitation_accepted`) after the yield, then we can use the block to complete the setup of the resource. This prevents the need to rewrite the controller in our own code, and we can do a lot more with the block.

I'm not sure how this fits with your approach. I get the feeling the current solution was quite intentional [(see this commit)](https://github.com/scambra/devise_invitable/commit/460e759e80519188efe16bd5fda5ff52f8480a00). I feel this change provides a lot more flexibility. But I don't know if existing implementations would break with this change?