### PR TITLE
Update README with working strong params example

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -221,13 +221,7 @@ Here is an example of what your application controller might need to include in 
   protected
 
   def configure_permitted_parameters
-    # Only add some parameters
-    devise_parameter_sanitizer.for(:accept_invitation).concat [:first_name, :last_name, :phone]
-    # Override accepted parameters
-    devise_parameter_sanitizer.for(:accept_invitation) do |u|
-      u.permit(:first_name, :last_name, :phone, :password, :password_confirmation,
-               :invitation_token)
-    end
+    devise_parameter_sanitizer.permit(:accept_invitation, keys: [:first_name, :last_name, :phone])
   end
 
 


### PR DESCRIPTION
The API for `Devise::ParameterSanitizer` changed here: https://github.com/plataformatec/devise/commit/e79201aef86e048ed38e2181675458bc3b9da2a1#diff-3d9087a6e7f173db4dd513c2139254ec

The new example worked for me with Devise 4.2.0 on Rails 5.0.0.1