### PR TITLE
Fix deprecated code

### DIFF
--- a/lib/devise_invitable/model.rb
+++ b/lib/devise_invitable/model.rb
@@ -306,7 +306,8 @@ module Devise
         end
 
         def invite!(attributes={}, invited_by=nil, options = {}, &block)
-          _invite(attributes.with_indifferent_access, invited_by, options, &block).first
+          attr_hash = ActiveSupport::HashWithIndifferentAccess.new(attributes.to_h)
+          _invite(attr_hash, invited_by, options, &block).first
         end
 
         def invite_mail!(attributes={}, invited_by=nil, options = {}, &block)


### PR DESCRIPTION
`ActionController::Parameters.with_indifferent_access` is deprecated and due to be removed in Rails 5.1

the `to_h` method provides similar functionality, but filters out unpermitted parameters. This should help avoid a security vulnerability in future.

https://github.com/scambra/devise_invitable/issues/694
