### PR TITLE
Set @accepting_invitation to false after accepting

### DIFF
--- a/lib/devise_invitable/model.rb
+++ b/lib/devise_invitable/model.rb
@@ -97,6 +97,7 @@ module Devise
             self.confirmed_at = self.invitation_accepted_at if self.respond_to?(:confirmed_at)
             self.save
           end
+          @accepting_invitation = false
         end
       end
 


### PR DESCRIPTION
We never set the @accepting_invitation variable to false after the invitation is accepted, so later calls to 'invitation_accepted?' on the same object ( even after user.reload ) return false, incorrectly.