### PR TITLE
Add ActiveRecord version to migration template

### DIFF
--- a/lib/generators/active_record/templates/migration.rb
+++ b/lib/generators/active_record/templates/migration.rb
@@ -1,4 +1,4 @@
-class DeviseInvitableAddTo<%= table_name.camelize %> < ActiveRecord::Migration
+class DeviseInvitableAddTo<%= table_name.camelize %> < ActiveRecord::Migration[<%= ActiveRecord::Migration.current_version %>]
   def up
     change_table :<%= table_name %> do |t|
       t.string     :invitation_token


### PR DESCRIPTION
Previously, the generated migration did not contain the ActiveRecord
version number. Since Rails 5 [1] version numbers are added to
migrations and since Rails 5.1 [2] migrations without a version number
will raise an exception and fail to run.

This commit adds the version number to the migration template so the
generated migration will run on Rails 5.1 apps.

[1] - https://github.com/rails/rails/commit/6940dc860c4b25bff2eded370f2af4316de15a30
[2] - https://github.com/rails/rails/commit/249f71a22ab21c03915da5606a063d321f04d4d3