### PR TITLE
Override `send_password_change_notification` to handle accepting invitation

### DIFF
--- a/lib/devise_invitable/model.rb
+++ b/lib/devise_invitable/model.rb
@@ -167,6 +167,11 @@ module Devise
         super unless !accepting_invitation? && block_from_invitation?
       end
 
+      # Prevent password changed email when accepting invitation
+      def send_password_change_notification?
+        super && !accepting_invitation?
+      end
+
       # Enforce password when invitation is being accepted
       def password_required?
         (accepting_invitation? && self.class.require_password_on_accepting) || super

--- a/test/models/invitable_test.rb
+++ b/test/models/invitable_test.rb
@@ -619,6 +619,24 @@ class InvitableTest < ActiveSupport::TestCase
     refute_predicate user, :confirmed?
   end
 
+  test 'should not send password change notification when accepting invitation' do
+    send_password_change_notification = User.send_password_change_notification
+
+    begin
+      User.send_password_change_notification = true
+
+      user = User.invite!(:email => "valid@email.com")
+
+      assert_no_difference('ActionMailer::Base.deliveries.size') do
+        user.password = user.password_confirmation = '123456789'
+        user.accept_invitation!
+      end
+
+    ensure
+      User.send_password_change_notification = send_password_change_notification
+    end
+  end
+
   def assert_callbacks_fired(callback, user)
     assert_callbacks_status callback, user, true
   end

--- a/test/rails_app/app/models/user.rb
+++ b/test/rails_app/app/models/user.rb
@@ -56,7 +56,7 @@ class User < PARENT_MODEL_CLASS
     object.after_invitation_accepted_callback_works = true
   end
 
-  def send_devise_notification(method, raw, *args)
+  def send_devise_notification(method, raw=nil, *args)
     Thread.current[:token] = raw
     super
   end


### PR DESCRIPTION
During accepting an invitation we don't want a password change notification on the user's first sign in. This checks the value of `accepting_invitation?`.

This fixes #679  