### PR TITLE
Hide invitable attributes from #inspect per #735

### DIFF
--- a/lib/devise_invitable.rb
+++ b/lib/devise_invitable.rb
@@ -84,4 +84,4 @@ module Devise
   @@require_password_on_accepting = true
 end
 
-Devise.add_module :invitable, :controller => :invitations, :model => 'devise_invitable/model', :route => {:invitation => [nil, :new, :accept]}
+Devise.add_module :invitable, :controller => :invitations, :model => 'devise_invitable/models', :route => {:invitation => [nil, :new, :accept]}

--- a/lib/devise_invitable/models.rb
+++ b/lib/devise_invitable/models.rb
@@ -1,4 +1,5 @@
 require 'active_support/deprecation'
+require 'devise_invitable/models/authenticatable'
 
 module Devise
   module Models

--- a/lib/devise_invitable/models/authenticatable.rb
+++ b/lib/devise_invitable/models/authenticatable.rb
@@ -1,0 +1,11 @@
+module Devise
+  module Models
+    module Authenticatable
+      BLACKLIST_FOR_SERIALIZATION.concat %i[
+        invitation_token invitation_created_at invitation_sent_at
+        invitation_accepted_at invitation_limit invited_by_type
+        invited_by_id invitations_count
+      ]
+    end
+  end
+end


### PR DESCRIPTION
See #735 for more details.

Also renamed `lib/devise_invitable/model.rb` to `lib/devise_invitable/models.rb` to match file hierarchy of Devise.