### PR TITLE
Fix invitation_period_valid? with no timestamp

### DIFF
--- a/lib/devise_invitable/models.rb
+++ b/lib/devise_invitable/models.rb
@@ -245,7 +245,7 @@ module Devise
         #
         def invitation_period_valid?
           time = invitation_created_at || invitation_sent_at
-          time && (self.class.invite_for.to_i.zero? || time.utc >= self.class.invite_for.ago)
+          self.class.invite_for.to_i.zero? || (time && time.utc >= self.class.invite_for.ago)
         end
 
         # Generates a new random token for invitation, and stores the time


### PR DESCRIPTION
If `invite_for` is 0, and therefore invitation expiries are disabled, there's no need for either `invitation_created_at` or `invitation_sent_at` to have been recorded.