### PR TITLE
replace newline in invitation_instructions.ignore with a space and remove logic in mailer template to render html

### DIFF
--- a/app/views/devise/mailer/invitation_instructions.html.erb
+++ b/app/views/devise/mailer/invitation_instructions.html.erb
@@ -8,4 +8,4 @@
   <p><%= t("devise.mailer.invitation_instructions.accept_until", due_date: l(@resource.invitation_due_at, format: :'devise.mailer.invitation_instructions.accept_until_format')) %></p>
 <% end %>
 
-<p><%= t("devise.mailer.invitation_instructions.ignore").html_safe %></p>
+<p><%= t("devise.mailer.invitation_instructions.ignore") %></p>

--- a/app/views/devise/mailer/invitation_instructions.text.erb
+++ b/app/views/devise/mailer/invitation_instructions.text.erb
@@ -8,4 +8,4 @@
   <%= t("devise.mailer.invitation_instructions.accept_until", due_date: l(@resource.invitation_due_at, format: :'devise.mailer.invitation_instructions.accept_until_format')) %>
 <% end %>
 
-<%= strip_tags t("devise.mailer.invitation_instructions.ignore") %>
+<%= t("devise.mailer.invitation_instructions.ignore") %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -22,7 +22,7 @@ en:
         someone_invited_you: "Someone has invited you to %{url}, you can accept it through the link below."
         accept: "Accept invitation"
         accept_until: "This invitation will be due in %{due_date}."
-        ignore: "If you don't want to accept the invitation, please ignore this email.<br />\nYour account won't be created until you access the link above and set your password."
+        ignore: "If you don't want to accept the invitation, please ignore this email. Your account won't be created until you access the link above and set your password."
   time:
     formats:
       devise:


### PR DESCRIPTION
This PR removes the need to call 'html_safe' in the invitation instructions template by using a space rather than a newline.

I am proposing this change because it has a minimal impact on the display of invitation instructions and has the benefit of removing 'html_safe' from the codebase.  While 'html_safe' is not a security vulnerability in this instance, I believe that it should be used only when absolutely necessary because its presence in codebases encourages further use without explicitly making the developer aware of the security issues it could cause when used with user generated text.