### PR TITLE
Only use confirmed_at= if respond_to confirmed_at=

### DIFF
--- a/lib/devise_invitable/models.rb
+++ b/lib/devise_invitable/models.rb
@@ -95,7 +95,7 @@ module Devise
           @accepting_invitation = true
           run_callbacks :invitation_accepted do
             self.accept_invitation
-            self.confirmed_at = self.invitation_accepted_at if self.respond_to?(:confirmed_at)
+            self.confirmed_at = self.invitation_accepted_at if self.respond_to?(:confirmed_at=)
             self.save
           end.tap { @accepting_invitation = false }
         end


### PR DESCRIPTION
I'm not sure how much sense this check made in its current form. Yes, it is somewhat reasonable to assume that a record that responds to `confirmed_at` will also respond to `confirmed_at=` but unfortunately due to the [way devise-multi_email works](https://github.com/scambra/devise_invitable/blob/master/lib/devise_invitable/models.rb#L98), this is not the case.