### PR TITLE
Ensure correct state of `invitation_token/invitation_accepted_at` fields.

### DIFF
--- a/lib/devise_invitable/models.rb
+++ b/lib/devise_invitable/models.rb
@@ -97,7 +97,10 @@ module Devise
             self.accept_invitation
             self.confirmed_at = self.invitation_accepted_at if self.respond_to?(:confirmed_at=)
             self.save
-          end.tap { @accepting_invitation = false }
+          end.tap do |saved|
+            self.restore_attributes([:invitation_token, :invitation_accepted_at, :confirmed_at]) if !saved
+            @accepting_invitation = false
+          end
         end
       end
 

--- a/lib/devise_invitable/models.rb
+++ b/lib/devise_invitable/models.rb
@@ -98,10 +98,16 @@ module Devise
             self.confirmed_at = self.invitation_accepted_at if self.respond_to?(:confirmed_at=)
             self.save
           end.tap do |saved|
-            self.restore_attributes([:invitation_token, :invitation_accepted_at, :confirmed_at]) if !saved
+            self.rollback_accepted_invitation if !saved
             @accepting_invitation = false
           end
         end
+      end
+
+      def rollback_accepted_invitation
+        self.invitation_token = self.invitation_token_was
+        self.invitation_accepted_at = nil
+        self.confirmed_at = nil if self.respond_to?(:confirmed_at=)
       end
 
       # Verify wheather a user is created by invitation, irrespective to invitation status

--- a/test/models/invitable_test.rb
+++ b/test/models/invitable_test.rb
@@ -228,9 +228,13 @@ class InvitableTest < ActiveSupport::TestCase
     assert user.invitation_token.present?
     assert_nil user.invitation_accepted_at
     user.accept_invitation!
+    assert_nil user.invitation_token
+    assert user.invitation_accepted_at.present?
+    assert user.invitation_accepted?
     user.reload
     assert_nil user.invitation_token
     assert user.invitation_accepted_at.present?
+    assert user.invitation_accepted?
   end
 
   test 'should not clear invitation token or set accepted_at if record is invalid' do
@@ -243,6 +247,17 @@ class InvitableTest < ActiveSupport::TestCase
     assert_equal old_encrypted_password, user.encrypted_password
     assert user.invitation_token.present?
     assert_nil user.invitation_accepted_at
+  end
+
+  test 'should not require reloading if invalid' do
+    user = User.invite!(:email => "valid@email.com")
+    assert user.invitation_token.present?
+    assert_nil user.invitation_accepted_at
+    user.attributes = { :password => '123456789', :password_confirmation => '987654321' }
+    user.accept_invitation!
+    assert user.invitation_token.present?
+    assert_nil user.invitation_accepted_at
+    assert !user.invitation_accepted?
   end
 
   test 'should clear invitation token while resetting the password' do


### PR DESCRIPTION
Ensure that `invitation_token/invitation_accepted_at` fields are rolled back on a failed `accept`, otherwise the user is left in a state where `invitation_accepted?` is true, but the user is invalid.

This issue was exposed by the recent fix that set `@accepting_invitation` to false after finishing accepting.