### PR TITLE
add allow_resend_invitation_for_existing_user config

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -131,6 +131,8 @@ or directly as parameters to the <tt>devise</tt> method:
 
 * resend_invitation: resend invitation if user with invited status is invited again. Enabled by default.
 
+* allow_resend_invitation_for_existing_user: allow resending invitations to existing users without invited status. Disabled by default.
+
 * invited_by_class_name: the class name of the inviting model. If this is nil, polymorphic association is used.
 
 * invited_by_foreign_key: the foreign key to the inviting model (only used if invited_by_class_name is set, otherwise :invited_by_id)

--- a/lib/devise_invitable.rb
+++ b/lib/devise_invitable.rb
@@ -57,6 +57,15 @@ module Devise
   mattr_accessor :resend_invitation
   @@resend_invitation = true
 
+  # Public: Allow resending invitations to existing users without invited status
+  # (default: false)
+  #
+  # Example (in config/initializers/devise.rb)
+  #
+  #   config.allow_resend_invitation_for_existing_user = true
+  mattr_accessor :allow_resend_invitation_for_existing_user
+  @@allow_resend_invitation_for_existing_user = false
+
   # Public: The class name of the inviting model. If this is nil,
   # the #invited_by association is declared to be polymorphic. (default: nil)
   mattr_accessor :invited_by_class_name

--- a/lib/devise_invitable/models.rb
+++ b/lib/devise_invitable/models.rb
@@ -284,10 +284,11 @@ module Devise
         end
 
         # Attempt to find a user by its email. If a record is not found,
-        # create a new user and send an invitation to it. If the user is found,
-        # return the user with an email already exists error.
-        # If the user is found and still has a pending invitation, invitation
-        # email is resent unless resend_invitation is set to false.
+        # create a new user and send an invitation to it.  If the user is found
+        # and resend_invitation is set to false, or the user does not have a pending
+        # invitation and allow_resend_invitation_for_existing_user is defaulted to
+        # false then the user will be returned with an email already taken error.
+        # Otherwise an invitation email is resent.
         # Attributes must contain the user's email, other attributes will be
         # set in the record
         def _invite(attributes={}, invited_by=nil, options = {}, &block)
@@ -309,7 +310,8 @@ module Devise
           invitable.valid? if self.validate_on_invite
           if invitable.new_record?
             invitable.clear_errors_on_valid_keys if !self.validate_on_invite
-          elsif !invitable.invited_to_sign_up? || !self.resend_invitation
+          elsif !self.resend_invitation ||
+                !invitable.invited_to_sign_up? && !self.allow_resend_invitation_for_existing_user
             invite_key_array.each do |key|
               invitable.errors.add(key, :taken)
             end
@@ -375,6 +377,7 @@ module Devise
         Devise::Models.config(self, :invitation_limit)
         Devise::Models.config(self, :invite_key)
         Devise::Models.config(self, :resend_invitation)
+        Devise::Models.config(self, :allow_resend_invitation_for_existing_user)
         Devise::Models.config(self, :invited_by_class_name)
         Devise::Models.config(self, :invited_by_foreign_key)
         Devise::Models.config(self, :invited_by_counter_cache)

--- a/lib/generators/devise_invitable/install_generator.rb
+++ b/lib/generators/devise_invitable/install_generator.rb
@@ -47,6 +47,10 @@ module DeviseInvitable
   # Default: true
   # config.resend_invitation = false
 
+  # Allow resending invitations to existing users without invited status
+  # Default: false
+  # config.allow_resend_invitation_for_existing_user = true
+
   # The class name of the inviting model. If this is nil,
   # the #invited_by association is declared to be polymorphic.
   # Default: nil


### PR DESCRIPTION
why: to facilitate situations where reinvitation of existing users is required