### PR TITLE
Remove recommendation to allow null password

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -70,11 +70,6 @@ or for a model that already exists, define a migration to add DeviseInvitable to
       add_column :users, :invited_by_id, :integer
       add_column :users, :invited_by_type, :string
       add_index :users, :invitation_token, unique: true
-
-      # Allow null encrypted_password
-      change_column_null :users, :encrypted_password, :string, true
-      # Allow null password_salt (add it if you are using Devise's encryptable module)
-      change_column_null :users, :password_salt, :string, true
   end
 
 If you previously used devise_invitable with a <tt>:limit</tt> on <tt>:invitation_token</tt>, remove it:


### PR DESCRIPTION
Since https://github.com/scambra/devise_invitable/pull/572 and https://github.com/scambra/devise_invitable/commit/2edcb130134950a1a1d869ffe2868ad4bb3c6359, a random password is generated by Devise Invitable, so there is no need to change the column null. Enforcing a not null value is actually desirable.