### PR TITLE
[Fix issue #810] Fix Ruby 2.7.0 deprecation warning

### DIFF
--- a/lib/devise_invitable/models.rb
+++ b/lib/devise_invitable/models.rb
@@ -45,7 +45,7 @@ module Devise
         elsif defined?(Mongoid) && defined?(Mongoid::Document) && self < Mongoid::Document && Mongoid::VERSION >= '6.0.0'
           belongs_to_options.merge! optional: true
         end
-        belongs_to :invited_by, belongs_to_options
+        belongs_to :invited_by, **belongs_to_options
 
         extend ActiveModel::Callbacks
         define_model_callbacks :invitation_created


### PR DESCRIPTION
Fixes the deprecation warning "Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call"

![image](https://user-images.githubusercontent.com/16024169/71719614-3bc74380-2e1f-11ea-9bd1-6ff643d64caf.png)

Handles #810 