### PR TITLE
Remove index on invitations_count column as it's probably not needed by everyone

### DIFF
--- a/lib/generators/active_record/templates/migration.rb
+++ b/lib/generators/active_record/templates/migration.rb
@@ -8,7 +8,6 @@ class DeviseInvitableAddTo<%= table_name.camelize %> < ActiveRecord::Migration<%
       t.integer    :invitation_limit
       t.references :invited_by, polymorphic: true
       t.integer    :invitations_count, default: 0
-      t.index      :invitations_count
       t.index      :invitation_token, unique: true # for invitable
       t.index      :invited_by_id
     end

--- a/test/rails_app/db/migrate/20100401102949_create_tables.rb
+++ b/test/rails_app/db/migrate/20100401102949_create_tables.rb
@@ -32,7 +32,6 @@ class CreateTables < (Rails.version < '5.1' ? ActiveRecord::Migration : ActiveRe
       t.timestamps :null => false
     end
     add_index :users, :invitation_token, :unique => true
-    add_index :users, :invitations_count
 
     create_table :admins do |t|
       ## Database authenticatable
@@ -41,6 +40,5 @@ class CreateTables < (Rails.version < '5.1' ? ActiveRecord::Migration : ActiveRe
 
       t.integer :invitations_count, :default => 0
     end
-    add_index :admins, :invitations_count
   end
 end


### PR DESCRIPTION
I don't think this index is needed unless someone wants to build some leaderboard kind of functionality. For most of the cases it will lie unused in the database. More details of the conversation can be found here (on the original PR where it was added):
https://github.com/scambra/devise_invitable/pull/425/files#r487461684