### PR TITLE
i18n fixed mistake in es.yml causing error on invite!

### DIFF
--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -18,7 +18,7 @@ es:
     mailer:
       invitation_instructions:
         subject: "Instruciones de la invitación"
-        hello: "Estimada/o %{nombre}"
+        hello: "Hola %{email}"
         someone_invited_you: "Has sido invitado a %{url}, puedes aceptarlo siguiendo el siguiente enlace"
         accept: "Aceptar la invitación"
         accept_until: "Esta invitación expirará en %{due_date}."


### PR DESCRIPTION
Initially the translation had an invalid argument `%{nombre}` causing `missing interpolation argument :nombre in "Estimada/o %{nombre}"`