### PR TITLE
Fix NoMethodError in random_password

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ webrat.log
 
 # Generated test files
 tmp/*
+test/rails_app/tmp/

--- a/lib/devise_invitable/models.rb
+++ b/lib/devise_invitable/models.rb
@@ -397,8 +397,10 @@ module Devise
           # lower + upper case, a digit and a symbol.
           # For more unusual rules, this method can be overridden.
           def random_password
+            length = respond_to?(:password_length) ? password_length : Devise.password_length
+
             prefix = 'aA1!'
-            prefix + Devise.friendly_token(Devise.password_length.last - prefix.length)
+            prefix + Devise.friendly_token(length.last - prefix.length)
           end
       end
     end

--- a/lib/devise_invitable/models.rb
+++ b/lib/devise_invitable/models.rb
@@ -398,7 +398,7 @@ module Devise
           # For more unusual rules, this method can be overridden.
           def random_password
             prefix = 'aA1!'
-            prefix + Devise.friendly_token(self.password_length.last-prefix.length)
+            prefix + Devise.friendly_token(Devise.password_length.last - prefix.length)
           end
       end
     end

--- a/test/models/invitable_test.rb
+++ b/test/models/invitable_test.rb
@@ -1,10 +1,6 @@
 require 'test_helper'
 require 'model_tests_helper'
 
-class Validatable < User
-  devise :validatable, password_length: 10..20
-end
-
 class InvitableTest < ActiveSupport::TestCase
 
   def setup
@@ -765,9 +761,9 @@ class InvitableTest < ActiveSupport::TestCase
     assert user.errors.empty?
   end
 
-  test 'should set initial password following devise password_length' do
-    user = Validatable.invite!(email: 'valid@email.com')
-    user.update_attributes(profile_id: 1)
+  test 'should set initial password following Devise.password_length' do
+    user = User.invite!(email: 'valid@email.com')
     assert_empty user.errors
+    assert_equal Devise.password_length.last, user.password.length
   end
 end

--- a/test/models/invitable_test.rb
+++ b/test/models/invitable_test.rb
@@ -1,6 +1,10 @@
 require 'test_helper'
 require 'model_tests_helper'
 
+class Validatable < User
+  devise :validatable, password_length: 10..20
+end
+
 class InvitableTest < ActiveSupport::TestCase
 
   def setup
@@ -765,5 +769,11 @@ class InvitableTest < ActiveSupport::TestCase
     user = User.invite!(email: 'valid@email.com')
     assert_empty user.errors
     assert_equal Devise.password_length.last, user.password.length
+  end
+
+  test 'should set initial passsword using :validatable with custom password_length' do
+    user = Validatable.invite!(email: 'valid@email.com')
+    assert_empty user.errors
+    assert_equal Validatable.password_length.last, user.password.length
   end
 end


### PR DESCRIPTION
The method `random_password` uses `self` to retrieve the `password_length` configuration, but `self` is the `User` class, which has no `password_length` by default.

This will result in:

```
     NoMethodError:
       undefined method `password_length' for #<Class:0x000000000ae64650>
```

when `User.invite!()` is called without a `password`. See also Forem's dependabot's integration build: https://github.com/forem/forem/pull/13383

The length of the password should be fetch from Devise's own config I think

Refs https://github.com/scambra/devise_invitable/pull/848