### PR TITLE
Fixing typo in es.yml and adding Catalan translation

### DIFF
--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -1,5 +1,5 @@
 
-es:
+ca:
   devise:
     failure:
       invited: "Tens una invitació pendent, accepta-la per acabar de crear el teu compte."

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -1,0 +1,32 @@
+
+es:
+  devise:
+    failure:
+      invited: "Tens una invitació pendent, accepta-la per acabar de crear el teu compte."
+    invitations:
+      send_instructions: "S'ha enviat una invitació a %{email}."
+      invitation_token_invalid: "La invitació no es vàlida!"
+      updated: "S'ha configurat la seva contrasenya i s'ha ingressat al sistema"
+      updated_not_active: "La seva contrasenya s'ha configurat correctament."
+      no_invitations_remaining: "No queden invitacions"
+      invitation_removed: "S'ha retirat la seva invitació"
+      new:
+        header: "Enviar Invitació"
+        submit_button: "Envia una invitació"
+      edit:
+        header: "Establir contrasenya"
+        submit_button: "Guardar la meva contrasenya"
+    mailer:
+      invitation_instructions:
+        subject: "Instruccions de la invitació"
+        hello: "Hola %{email}"
+        someone_invited_you: "Has estat invitat a %{url}, pots acceptar-ho seguint el següent enllaç"
+        accept: "Aceptar la invitació"
+        accept_until: "Aquesta invitació expirarà en %{due_date}."
+        ignore: "Si no li interessa aquesta invitació, simplement ignori aquest correu. No es crearà el teu compte fins que accedeixis a l'anterior enllaç i creïs una contrasenya"
+  time:
+    formats:
+      devise:
+        mailer:
+          invitation_instructions:
+            accept_until_format: "%d de %B de %Y, %H:%M"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -17,7 +17,7 @@ es:
         submit_button: "Guardar mi contraseña"
     mailer:
       invitation_instructions:
-        subject: "Instruciones de la invitación"
+        subject: "Instrucciones de la invitación"
         hello: "Hola %{email}"
         someone_invited_you: "Has sido invitado a %{url}, puedes aceptarlo siguiendo el siguiente enlace"
         accept: "Aceptar la invitación"


### PR DESCRIPTION
Fixing a typo in the Spanish translation: "instruciones" should be "instructions".

Also including a new language: Catalan.