### PR TITLE
Fix obsolete symbols in German translation

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1,31 +1,31 @@
-de:                                                                                                                                                                       
-  devise:                                                                                                                                                                 
-    failure:                                                                                                                                                              
-      invited: "Du hast bereits eine Einladung erhalten. Nimm die Einladung an um dein Nutzerkonto zu erstellen."                                                         
-    invitations:                                                                                                                                                          
-      send_instructions: "Eine Einladung wurde an %{email} verschickt."                                                                                                   
-      invitation_token_invalid: "Der Einladungs-Code ist ungültig!"                                                                                                       
-      updated: "Dein Passwort wurde gesetzt. Du bist nun angemeldet."                                                                                                     
-      updated_not_active: "Dein Passwort wurde gesetzt."                                                                                                                  
-      no_invitations_remaining: "Es gibt keine weiteren Einladungen"                                                                                                      
-      invitation_removed: "Deine Einladung wurde gelöscht."                                                                                                               
-      new:                                                                                                                                                                
-        header: "Einladung schicken"                                                                                                                                      
-        submit_button: "Einladung schicken"                                                                                                                               
-      edit:                                                                                                                                                               
-        header: "Setze ein Passwort"                                                                                                                                      
-        submit_button: "Passwort setzen"                                                                                                                                  
-    mailer:                                                                                                                                                               
-      invitation_instructions:                                                                                                                                            
-        subject: "Einladung"                                                                                                                                              
-        hello: "Hallo %{email}"                                                                                                                                           
-        someone_invited_you: "Jemand hat dich zu %{url} eingeladen. Du kannst die Einladung mit dem Link unten annehmen."                                                 
-        accept: "Einladung annehmen"                                                                                                                                      
-        accept_until: "Diese Einladung ist gültig bis zum %{due_date}."                                                                                                   
-        ignore: "Wenn du die Einladung nicht annehmen willst, ignoriere diese E-Mail einfach. Es wird kein Benutzerkonto erstellt solange du nicht die Einladung mittels des Links oben annimmst."                                                                                                                                          
-  time:                                                                                                                                                                   
-    formats:                                                                                                                                                              
-      devise:                                                                                                                                                             
-        mailer:                                                                                                                                                           
-          invitation_instructions:                                                                                                                                        
+de:
+  devise:
+    failure:
+      invited: "Du hast bereits eine Einladung erhalten. Nimm die Einladung an um dein Nutzerkonto zu erstellen."
+    invitations:
+      send_instructions: "Eine Einladung wurde an %{email} verschickt."
+      invitation_token_invalid: "Der Einladungs-Code ist ungültig!"
+      updated: "Dein Passwort wurde gesetzt. Du bist nun angemeldet."
+      updated_not_active: "Dein Passwort wurde gesetzt."
+      no_invitations_remaining: "Es gibt keine weiteren Einladungen"
+      invitation_removed: "Deine Einladung wurde gelöscht."
+      new:
+        header: "Einladung schicken"
+        submit_button: "Einladung schicken"
+      edit:
+        header: "Setze ein Passwort"
+        submit_button: "Passwort setzen"
+    mailer:
+      invitation_instructions:
+        subject: "Einladung"
+        hello: "Hallo %{email}"
+        someone_invited_you: "Jemand hat dich zu %{url} eingeladen. Du kannst die Einladung mit dem Link unten annehmen."
+        accept: "Einladung annehmen"
+        accept_until: "Diese Einladung ist gültig bis zum %{due_date}."
+        ignore: "Wenn du die Einladung nicht annehmen willst, ignoriere diese E-Mail einfach. Es wird kein Benutzerkonto erstellt solange du nicht die Einladung mittels des Links oben annimmst."
+  time:
+    formats:
+      devise:
+        mailer:
+          invitation_instructions:
             accept_until_format: "%d. %B %Y %H:%M"

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -22,7 +22,7 @@ de:
         someone_invited_you: "Jemand hat dich zu %{url} eingeladen. Du kannst die Einladung mit dem Link unten annehmen."                                                 
         accept: "Einladung annehmen"                                                                                                                                      
         accept_until: "Diese Einladung ist gültig bis zum %{due_date}."                                                                                                   
-        ignore: "Wenn du die Einladung nicht annehmen willst, ignoriere diese E-Mail einfach.<br />\nEs wird kein Benutzerkonto erstellt solange du nicht die Einladung mi↪ttels des Links oben annimmst."                                                                                                                                          
+        ignore: "Wenn du die Einladung nicht annehmen willst, ignoriere diese E-Mail einfach. Es wird kein Benutzerkonto erstellt solange du nicht die Einladung mittels des Links oben annimmst."                                                                                                                                          
   time:                                                                                                                                                                   
     formats:                                                                                                                                                              
       devise:                                                                                                                                                             


### PR DESCRIPTION
There are small errrors in the German translation:

- The `<br />` in the text is not rendered. As there is no linebreak in the English text, I'd propose to remove it.
- There is an extra symbol in the word `mittels`. Maybe from the wiki import? That symbol shouldn't be there though.
- When downloading the file, I noticed that there are a lot of whitespaces at the end of every line. Removed those as well.