### PR TITLE
Allow customizing invalid token path

### DIFF
--- a/app/controllers/devise/invitations_controller.rb
+++ b/app/controllers/devise/invitations_controller.rb
@@ -99,7 +99,7 @@ class Devise::InvitationsController < DeviseController
     def resource_from_invitation_token
       unless params[:invitation_token] && self.resource = resource_class.find_by_invitation_token(params[:invitation_token], true)
         set_flash_message(:alert, :invitation_token_invalid) if is_flashing_format?
-        redirect_to after_sign_out_path_for(resource_name)
+        redirect_to invalid_token_path_for(resource_name)
       end
     end
 

--- a/lib/devise_invitable/controllers/helpers.rb
+++ b/lib/devise_invitable/controllers/helpers.rb
@@ -12,6 +12,10 @@ module DeviseInvitable::Controllers::Helpers
     signed_in_root_path(resource)
   end
 
+  def invalid_token_path_for(resource_name)
+    after_sign_out_path_for(resource_name)
+  end
+
   protected
 
     def authenticate_inviter!

--- a/test/functional/controller_helpers_test.rb
+++ b/test/functional/controller_helpers_test.rb
@@ -41,4 +41,14 @@ class ControllerHelpersTest < ActionController::TestCase
     assert Devise::InvitationsController.method_defined? :after_accept_path_for
     assert !Devise::InvitationsController.instance_methods(false).include?(:after_accept_path_for)
   end
+
+  test 'invalid token path defaults to after sign out path' do
+    assert_equal @controller.send(:after_sign_out_path_for, :user), @controller.invalid_token_path_for(:user)
+  end
+
+  test 'invalid token path is customizable from application controller' do
+    custom_path = 'customized/invalid/token/path'
+    @controller.instance_eval "def invalid_token_path_for(resource_name) '#{custom_path}' end"
+    assert_equal @controller.invalid_token_path_for(:user), custom_path
+  end
 end


### PR DESCRIPTION
This commit introduces an 'invalid_token_path_for' method in the controller helpers that allows customizing the path to which invited users are redirected to in the event where their invitation token is invalid.