### PR TITLE
Add note to callbacks section

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -341,7 +341,7 @@ To accept an invitation with a token use the <tt>accept_invitation!</tt> class m
 === Callbacks
 
 A callback event is fired before and after an invitation is created (User#invite!) or accepted (User#accept_invitation!). For example, in your resource model you can add:
-
+  # Note: callbacks should be placed after devise: :invitable is specified.
   before_invitation_created :email_admins
   after_invitation_accepted :email_invited_by
 


### PR DESCRIPTION
This is tiny PR that will help users to place callbacks in a right place, cause if you place it before devise setup gets called it won't work. Thanks.