### PR TITLE
Do not accept expired invitation on password reset

### DIFF
--- a/lib/devise_invitable/models.rb
+++ b/lib/devise_invitable/models.rb
@@ -195,7 +195,7 @@ module Devise
       def clear_reset_password_token
         reset_password_token_present = reset_password_token.present?
         super
-        accept_invitation! if reset_password_token_present && invited_to_sign_up?
+        accept_invitation! if reset_password_token_present && valid_invitation?
       end
 
       def clear_errors_on_valid_keys
@@ -231,7 +231,7 @@ module Devise
       def add_taken_error(key)
         errors.add(key, :taken)
       end
-    
+
       def invitation_taken?
         !invited_to_sign_up?
       end


### PR DESCRIPTION
The password reset functionality is overridden to always accept the pending invitation on password reset.

This should not happen for expired invitations because this is how the user can circumvent the invitation expiry period which can be a security issue in some contexts.

This PR fixes the issue and adds a test for this case.