### PR TITLE
Update v1.7 to fix devise deprecations

### DIFF
--- a/lib/devise_invitable/models/authenticatable.rb
+++ b/lib/devise_invitable/models/authenticatable.rb
@@ -1,11 +1,17 @@
 module Devise
   module Models
     module Authenticatable
-      BLACKLIST_FOR_SERIALIZATION.concat %i[
+      list = %i[
         invitation_token invitation_created_at invitation_sent_at
         invitation_accepted_at invitation_limit invited_by_type
         invited_by_id invitations_count
       ]
+      
+      if defined?(UNSAFE_ATTRIBUTES_FOR_SERIALIZATION)
+        UNSAFE_ATTRIBUTES_FOR_SERIALIZATION.concat(list)
+      else
+        BLACKLIST_FOR_SERIALIZATION.concat(list)
+      end
     end
   end
 end


### PR DESCRIPTION
Hoping we can make these changes so I can continue to use devise-invitable v1.7 with the newer devise versions. Thanks!