### PR TITLE
Some changes in fr.yml

### DIFF
--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -4,14 +4,13 @@ fr:
       invited: "Vous avez une invitation en attente, acceptez-la pour terminer la création de votre compte."
     invitations:
       send_instructions: "Un e-mail d'invitation a été envoyé à %{email}."
-      invitation_token_invalid: "Le jeton d'invitation fourni n'est pas valide!"
+      invitation_token_invalid: "Le jeton d'invitation fourni n'est pas valide !"
       updated: 'Votre mot de passe a été défini avec succès. Vous êtes maintenant connecté.'
       updated_not_active: "Votre mot de passe a été défini avec succès."
-      no_invitations_remaining: "Il n'y a plus d'invitations restantes"
+      no_invitations_remaining: "Il n'y a plus d'invitations restantes."
       invitation_removed: 'Votre invitation a été supprimée.'
       new:
         header: Nouvel utilisateur
-        legend: Envoyer l’invitation
         submit_button: Envoyer
       edit:
         header: Définissez votre mot de passe
@@ -23,10 +22,10 @@ fr:
         someone_invited_you: "Vous avez été invité à rejoindre %{url}, vous pouvez accepter cette invitation via le lien ci-dessous."
         accept: "Accepter l'invitation"
         accept_until: "Cette invitation sera valable jusqu'au %{due_date}."
-        ignore: "Si vous ne souhaitez pas accepter cette invitation, veuillez ignorer cet e-mail.<br />Votre compte ne sera pas créé tant que vous n'accéderez pas au lien ci-dessous et que vous ayez défini votre mot de passe."
+        ignore: "Si vous ne souhaitez pas accepter cette invitation, veuillez ignorer cet e-mail. Votre compte ne sera pas créé tant que vous n'aurez pas cliqué sur le lien ci-dessous et défini votre mot de passe."
   time:
     formats:
       devise:
         mailer:
           invitation_instructions:
-            accept_until_format: "%B %d, %Y %I:%M %p"
+            accept_until_format: "%d %B %Y à %H:%M"


### PR DESCRIPTION
First of all thank you for this repo it is super useful ✨ 

## Description:
Some fixing in the French translation.

## Changes:
- The time is indicated on a 12h basis, but most French-speaking countries use a 24h basis. (I checked for Quebec and that's the case too).
- `legend` doesn't seem to be used anymore, so I removed it.
- I've clarified a sentence
- There's a strange rule, but in French all double punctuation marks have a space before and after them. So I add an space before `!`
- The `</br>` is not rendered in the mail so I removed it.
<img width="345" alt="Screenshot 2024-03-05 at 12 10 35" src="https://github.com/scambra/devise_invitable/assets/16155041/d6f8f305-4763-4eb2-b90a-f61ae0e513e6">
