### PR TITLE
Add security caution for role assignment in user invitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,8 @@ authentication keys (like `email`)
 
 Here is an example of the steps needed to add a first_name, last_name and role to invited Users.
 
+Caution: Adding roles requires additional security measures, such as preventing a standard user from inviting an administrator. Implement appropriate access controls to ensure system security.
+
 ### Configuring your application controller to accept :first_name, :last_name, and :role for a User
 
 Note: These modifications can be applied directly in the InvitationsController if not needed for other Devise actions.

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ more information about views.
 
 To change the controller's behavior, create a controller that inherits from
 `Devise::InvitationsController`. The available methods are: `new`, `create`,
-`edit`, and `update`. Refer to the [original controllers source](https://github.com/scambra/devise_invitable/blob/master/app/controllers/devise/invitations_controller.rb) 
+`edit`, and `update`. Refer to the [original controllers source](https://github.com/scambra/devise_invitable/blob/master/app/controllers/devise/invitations_controller.rb)
 before editing any of these actions. Your
 controller might now look something like this:
 
@@ -327,7 +327,7 @@ protected
 Here is an example setting a User's first name, last name, and role for a
 custom invitation:
 
-# Configuring the InvitationsController to accept :first_name, :last_name, and :role
+### Configuring the InvitationsController to accept :first_name, :last_name, and :role
 
 ```ruby
 class Users::InvitationsController < Devise::InvitationsController
@@ -342,7 +342,7 @@ class Users::InvitationsController < Devise::InvitationsController
 end
 ```
 
-# Define your roles in the User model
+### Define your roles in the User model
 
 ```ruby
 class User < ApplicationRecord
@@ -352,7 +352,7 @@ class User < ApplicationRecord
 end
 ```
 
-# In the Invitation view
+### In the Invitation view
 
 ```ruby
 <h2><%= t "devise.invitations.new.header" %></h2>

--- a/README.md
+++ b/README.md
@@ -310,28 +310,14 @@ authentication keys (like `email`)
 *   `accept_invitation` (Devise::InvitationsController#update) - Permits
 `invitation_token` plus `password` and `password_confirmation`.
 
+Here is an example of the steps needed to add a first_name, last_name and role to invited Users.
 
-Here is an example of what your application controller might need to include
-in order to add these parameters to the invitation view:
+### Configuring your application controller to accept :first_name, :last_name, and :role for a User
 
-```ruby
-before_action :configure_permitted_parameters, if: :devise_controller?
-
-protected
-
-  def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:accept_invitation, keys: [:first_name, :last_name, :phone])
-  end
-```
-
-Here is an example setting a User's first name, last name, and role for a
-custom invitation:
-
-### Configuring the InvitationsController to accept :first_name, :last_name, and :role
+Note: These modifications can be applied directly in the InvitationsController if not needed for other Devise actions.
 
 ```ruby
-class Users::InvitationsController < Devise::InvitationsController
-  before_action :configure_permitted_parameters
+  before_action :configure_permitted_parameters, if: :devise_controller?
 
   protected
 
@@ -339,7 +325,6 @@ class Users::InvitationsController < Devise::InvitationsController
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:invite, keys: [:first_name, :last_name, :role])
   end
-end
 ```
 
 ### Define your roles in the User model


### PR DESCRIPTION
Adds security note to the documentation. It warns about the potential security risks when implementing role assignment during the invitation process. The goal is to prevent inadvertent security vulnerabilities, such as allowing standard users to invite administrators.

Key changes:
- Added a caution message about role-based security considerations
- Slightly reorganized the existing documentation for clarity and to avoid duplications