### PR TITLE
Fix invitation_due_at for not-invited users

### DIFF
--- a/lib/devise_invitable/models.rb
+++ b/lib/devise_invitable/models.rb
@@ -222,7 +222,7 @@ module Devise
 
       def invitation_due_at
         return nil if (self.class.invite_for == 0 || self.class.invite_for.nil?)
-        #return nil unless self.class.invite_for
+        return nil if !invitation_created_at.nil? && !self.invitation_sent_at
 
         time = self.invitation_created_at || self.invitation_sent_at
         time + self.class.invite_for


### PR DESCRIPTION
If a user isn't invited (it was manually created via the console or seeds file, for instance) it doesn't have `invitation_created_at` and `invitation_sent_at`, which makes this method break when called.