### PR TITLE
Update pt-BR.yml to use proper code

### DIFF
--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -1,4 +1,4 @@
-pt_BR:
+pt-BR:
   devise:
     failure:
       invited: 'Você tem um convite pendente, aceite para finalizar sua conta.'


### PR DESCRIPTION
Hello! A simple change, here, which shouldn't affect anybody except to potentially remove a warning the, afaik, `I18n` gem throws on load of these locale files: (we've been getting by a long while without noticing this, but it was notably noisy today.)

```
INVALID I18N: File "/home/.../.rbenv/versions/3.1.7/lib/ruby/gems/3.1.0/gems/devise_invitable-2.0.6/config/locales/pt-BR.yml" contains translations for unexpected locale
       valid: [:"pt-BR", :pt, :"en-US", :en]
    expected: :"pt-BR"
  unexpected: [:pt_BR]
```

Cheers!