### PR TITLE
Defer mailer include via ActiveSupport.on_load(:action_mailer)

### DIFF
--- a/lib/devise_invitable/rails.rb
+++ b/lib/devise_invitable/rails.rb
@@ -8,10 +8,18 @@ module DeviseInvitable
     # We use to_prepare instead of after_initialize here because Devise is a Rails engine; its
     # mailer is reloaded like the rest of the user's app.  Got to make sure that our mailer methods
     # are included each time Devise.mailer is (re)loaded.
+    #
+    # The work is wrapped in ActiveSupport.on_load(:action_mailer) so that resolving
+    # Devise.mailer (a String#constantize) doesn't force ActionMailer::Base to load
+    # before app initialization completes. Without this wrapper, Rails edge's
+    # guard_load_hooks support (rails/rails#56201) logs an early-load-hook warning
+    # for :action_mailer (and :active_job, via MailDeliveryJob) on every boot.
     config.to_prepare do
-      Devise.mailer.send :include, DeviseInvitable::Mailer
-      unless Devise.mailer.ancestors.include?(Devise::Mailers::Helpers)
-        Devise.mailer.send :include, Devise::Mailers::Helpers 
+      ActiveSupport.on_load(:action_mailer) do
+        Devise.mailer.send :include, DeviseInvitable::Mailer
+        unless Devise.mailer.ancestors.include?(Devise::Mailers::Helpers)
+          Devise.mailer.send :include, Devise::Mailers::Helpers
+        end
       end
     end
     # extend mapping with after_initialize because it's not reloaded


### PR DESCRIPTION
Fixes #925.

`config.to_prepare` in the Engine forces `Devise.mailer` to constantize during the Rails finisher initializer, which in turn loads `ActionMailer::Base` (and, via `MailDeliveryJob`, `ActiveJob::Base`) before `Rails.application.initialized?` flips. Rails edge's new [`guard_load_hooks` support (rails/rails#56201)](https://github.com/rails/rails/pull/56201) reports this as a premature load-hook for both `:action_mailer` and `:active_job` on every boot.

This change wraps the body of the `to_prepare` block in `ActiveSupport.on_load(:action_mailer)`:

- **First boot.** `to_prepare` registers an `on_load(:action_mailer)` hook. Nothing loads `ActionMailer::Base` yet. When something later resolves a mailer (sending an invitation, etc.), the hook fires and the include runs against the loaded mailer class. App init has already completed, so no warning.
- **Subsequent `to_prepare` cycles (dev reloads).** `:action_mailer` has already fired, so the freshly-registered `on_load` block runs immediately, re-applying the include on the reloaded `Devise.mailer` class — same behaviour as before.

No functional change for stable Rails users; just silences the boot warnings on Rails edge and saves a small amount of boot time by deferring the mailer load.

I didn't add a regression test — wasn't sure how to best exercise railtie load order in the existing harness. Happy to add one if you'd like, or to take suggestions on the right approach.